### PR TITLE
Fix .travis.yaml CI script to allow develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: (branch = development) OR (branch = master) OR (type = pull_request) OR (tag IS present)
+if: (branch = develop) OR (branch = master) OR (type = pull_request) OR (tag IS present)
 language: node_js
 node_js:
   - "stable"
@@ -22,7 +22,7 @@ after_success:
   - ./travis/deploy_release.sh
 
 deploy:
-  # Development environment
+  # Develop environment
 - provider: s3
   bucket: $DEV_BUCKET_NAME
   access_key_id: $AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Fix a .travis.yaml CI script typo `development` to the right name branch `develop`.