### PR TITLE
Use collateral with error and loading

### DIFF
--- a/src/components/modals/CustomCollateralModal/index.tsx
+++ b/src/components/modals/CustomCollateralModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import { Button } from 'components/buttons'
@@ -29,16 +29,8 @@ interface Props extends ModalProps {
 export const CustomCollateralModal: React.FC<Props> = (props) => {
   const { onAdd, onRequestClose, ...restProps } = props
   const [collateralAddress, setCollateralAddress] = useState<string>('')
-  const [isLoading, setIsLoading] = useState(false)
-  const [error, setError] = useState<string>()
 
-  const collateralData = useCollateral(collateralAddress)
-
-  useEffect(() => {
-    if (collateralData) {
-      setIsLoading(false)
-    }
-  }, [collateralData])
+  const { collateral: collateralData, error, loading } = useCollateral(collateralAddress)
 
   const onClickAddButton = (
     e: React.MouseEvent<Element, MouseEvent> | React.KeyboardEvent<Element>
@@ -69,31 +61,21 @@ export const CustomCollateralModal: React.FC<Props> = (props) => {
                 onChange={(event) => {
                   const { value } = event.target
                   setCollateralAddress(value)
-                  setIsLoading(true)
-                  // Note: This is just a mockery to test displaying errors, we should
-                  // show proper informative errors
-                  if (value.length < 16) {
-                    setError('Not a valid contract address.')
-                  } else {
-                    setError('')
-                  }
                 }}
                 placeholder="A valid contract address..."
                 type="text"
               />
               {error && (
                 <ErrorContainer>
-                  <Error>{error}</Error>
+                  <Error>{error.message}</Error>
                 </ErrorContainer>
               )}
             </>
           }
         />
       </FirstRow>
-      {!collateralData && (
-        <SpinnerWrapper>{isLoading && !error && <InlineLoading />}</SpinnerWrapper>
-      )}
-      {!isLoading && collateralData && (
+      {!collateralData && <SpinnerWrapper>{loading && !error && <InlineLoading />}</SpinnerWrapper>}
+      {!loading && collateralData && (
         <Row>
           <TitleValue title={'Token Symbol'} value={collateralData && collateralData.symbol} />
           <TitleValue

--- a/src/components/splitPosition/PositionPreview/index.tsx
+++ b/src/components/splitPosition/PositionPreview/index.tsx
@@ -34,7 +34,9 @@ export const PositionPreview = ({
   selectedCollateral,
   splitFrom,
 }: Props) => {
-  const positionCollateral = useCollateral(position ? position.collateralToken.id : '')
+  const { collateral: positionCollateral } = useCollateral(
+    position ? position.collateralToken.id : ''
+  )
   const splitFromCollateral = useMemo(() => splitFrom === SplitFromType.collateral, [splitFrom])
   const splitFromPosition = useMemo(() => splitFrom === SplitFromType.position, [splitFrom])
 

--- a/src/hooks/useCollateral.tsx
+++ b/src/hooks/useCollateral.tsx
@@ -4,10 +4,14 @@ import { useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
 import { ERC20Service } from 'services/erc20'
 import { Token } from 'util/types'
 
-export const useCollateral = (collateralAddress: string): Maybe<Token> => {
+export const useCollateral = (
+  collateralAddress: string
+): { collateral: Maybe<Token>; error: Maybe<Error>; loading: boolean } => {
   const { _type: status, networkConfig, provider } = useWeb3ConnectedOrInfura()
 
   const [collateral, setCollateral] = React.useState<Maybe<Token>>(null)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<Maybe<Error>>(null)
 
   React.useEffect(() => {
     let cancelled = false
@@ -25,25 +29,32 @@ export const useCollateral = (collateralAddress: string): Maybe<Token> => {
       }
 
       // try to recover ERC20 profile
-      try {
-        const erc20Service = new ERC20Service(provider, collateral)
-        const token = await erc20Service.getProfileSummary()
-        return token
-      } catch (e) {
-        return null
-      }
+      const erc20Service = new ERC20Service(provider, collateral)
+      const token = await erc20Service.getProfileSummary()
+      return token
     }
 
-    fetchToken(collateralAddress).then((token) => {
-      if (!cancelled) {
-        setCollateral(token)
-      }
-    })
+    setLoading(true)
+    fetchToken(collateralAddress)
+      .then((token) => {
+        if (!cancelled) {
+          setCollateral(token)
+          setLoading(false)
+          setError(null)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setLoading(false)
+          setCollateral(null)
+          setError(err)
+        }
+      })
 
     return () => {
       cancelled = true
     }
   }, [status, provider, collateralAddress, networkConfig])
 
-  return collateral
+  return { loading, error, collateral }
 }

--- a/src/pages/PositionDetails/Contents.tsx
+++ b/src/pages/PositionDetails/Contents.tsx
@@ -8,20 +8,13 @@ import { ButtonDropdownCircle } from 'components/buttons/ButtonDropdownCircle'
 import { CenteredCard } from 'components/common/CenteredCard'
 import { Dropdown, DropdownItem, DropdownPosition } from 'components/common/Dropdown'
 import { TokenIcon } from 'components/common/TokenIcon'
-import { Outcome } from 'components/partitions/Outcome'
-import { CardTextSm } from 'components/pureStyledComponents/CardText'
 import { Row } from 'components/pureStyledComponents/Row'
-import {
-  StripedList,
-  StripedListItem,
-  StripedListItemLessPadding,
-} from 'components/pureStyledComponents/StripedList'
+import { StripedList, StripedListItem } from 'components/pureStyledComponents/StripedList'
 import { TitleValue } from 'components/text/TitleValue'
 import { useBalanceForPosition } from 'hooks/useBalanceForPosition'
 import { useCollateral } from 'hooks/useCollateral'
 import { useLocalStorage } from 'hooks/useLocalStorageValue'
 import { GetPosition_position as Position } from 'types/generatedGQL'
-import { getLogger } from 'util/logger'
 import { positionString, truncateStringInTheMiddle } from 'util/tools'
 
 const CollateralText = styled.span`
@@ -51,8 +44,6 @@ const StripedListStyled = styled(StripedList)`
   margin-top: 6px;
 `
 
-const logger = getLogger('ConditionDetails')
-
 interface Props {
   position: Position
 }
@@ -62,18 +53,11 @@ export const Contents = ({ position }: Props) => {
   const { setValue } = useLocalStorage('positionid')
   const { balance, error, loading } = useBalanceForPosition(position.id)
 
-  const positionCollateral = useCollateral(position ? position.collateralToken.id : '')
+  const { collateral: positionCollateral } = useCollateral(
+    position ? position.collateralToken.id : ''
+  )
   const [collateralSymbol, setCollateralSymbol] = React.useState('')
-  const { collateralToken, id, indexSets } = position
-
-  const numberedOutcomes = indexSets.map((indexSet: string) => {
-    return Number(indexSet)
-      .toString(2)
-      .split('')
-      .reverse()
-      .map((value, index) => (value === '1' ? index + 1 : 0))
-      .filter((n) => !!n)
-  })
+  const { collateralToken, id } = position
 
   const dropdownItems = useMemo(() => {
     return [
@@ -178,29 +162,8 @@ export const Contents = ({ position }: Props) => {
       </Row>
       <Row cols="1fr" marginBottomXL>
         <TitleValue
-          title="Partition"
-          value={
-            <>
-              <CardTextSm>Collections</CardTextSm>
-              <StripedListStyled>
-                {
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  numberedOutcomes.map((outcomeList: unknown | any, outcomeListIndex: number) => {
-                    return (
-                      <StripedListItemLessPadding key={outcomeListIndex}>
-                        {outcomeList.map((outcome: string, outcomeIndex: number) => (
-                          <Outcome
-                            key={outcomeIndex}
-                            outcome={{ value: parseInt(outcome), id: '' }}
-                          />
-                        ))}
-                      </StripedListItemLessPadding>
-                    )
-                  })
-                }
-              </StripedListStyled>
-            </>
-          }
+          title="Position"
+          value={<StripedListItem>{positionPreview || ''} </StripedListItem>}
         />
       </Row>
     </CenteredCard>

--- a/src/pages/SplitPosition/index.tsx
+++ b/src/pages/SplitPosition/index.tsx
@@ -22,7 +22,7 @@ export const SplitPosition = () => {
   const [collateral, setCollateral] = useState<string>(tokens[0].address)
   const [isLoading, setIsLoading] = useState(true)
   const allowanceMethods = useAllowance(collateral)
-  const collateralToken = useCollateral(collateral)
+  const { collateral: collateralToken } = useCollateral(collateral)
 
   const splitPosition = React.useCallback(
     async (


### PR DESCRIPTION
Closes #172 

This change `useCollateral` hook to return error and loading state. When you add a custom token in split position page we should see a spinner or an error. Errors have the original message, maybe this could be improved mapping common errors to a string.