### PR TITLE
(Feature) Connect modal styles

### DIFF
--- a/src/theme/globalStyle.tsx
+++ b/src/theme/globalStyle.tsx
@@ -4,6 +4,7 @@ import { dataTableCSS } from 'theme/dataTableCSS'
 import { localFonts } from 'theme/fonts'
 import theme from 'theme/index'
 import { reactTooltipCSS } from 'theme/reactTooltipCSS'
+import { walletConnectCSS } from 'theme/walletConnectCSS'
 import { web3ModalCSS } from 'theme/web3ModalCSS'
 
 type ThemeType = typeof theme
@@ -31,6 +32,7 @@ export const GlobalStyle = createGlobalStyle<{ theme: ThemeType }>`
   }
 
   ${web3ModalCSS}
+  ${walletConnectCSS}
   ${dataTableCSS}
   ${reactTooltipCSS}
 `

--- a/src/theme/walletConnectCSS.tsx
+++ b/src/theme/walletConnectCSS.tsx
@@ -1,0 +1,20 @@
+import { css } from 'styled-components'
+
+export const walletConnectCSS = css`
+  #walletconnect-wrapper {
+    .walletconnect-modal__header p {
+      color: ${(props) => props.theme.colors.darkBlue};
+    }
+    .walletconnect-qrcode__base {
+      background-color: ${(props) => props.theme.modalStyle.overlay.backgroundColor};
+    }
+    .walletconnect-modal__base {
+      border-radius: ${(props) => props.theme.modalStyle.content.borderRadius};
+      box-shadow: ${(props) => props.theme.modalStyle.content.boxShadow};
+    }
+    .walletconnect-qrcode__text {
+      color: ${(props) => props.theme.colors.textColor};
+      font-size: 16px;
+    }
+  }
+`

--- a/src/theme/walletConnectCSS.tsx
+++ b/src/theme/walletConnectCSS.tsx
@@ -6,7 +6,7 @@ export const walletConnectCSS = css`
       color: ${(props) => props.theme.colors.darkBlue};
     }
     .walletconnect-qrcode__base {
-      background-color: transparent;
+      background-color: ${(props) => props.theme.modalStyle.overlay.backgroundColor};
     }
     .walletconnect-modal__base {
       border-radius: ${(props) => props.theme.modalStyle.content.borderRadius};

--- a/src/theme/walletConnectCSS.tsx
+++ b/src/theme/walletConnectCSS.tsx
@@ -6,7 +6,7 @@ export const walletConnectCSS = css`
       color: ${(props) => props.theme.colors.darkBlue};
     }
     .walletconnect-qrcode__base {
-      background-color: ${(props) => props.theme.modalStyle.overlay.backgroundColor};
+      background-color: transparent;
     }
     .walletconnect-modal__base {
       border-radius: ${(props) => props.theme.modalStyle.content.borderRadius};

--- a/src/theme/web3ModalCSS.tsx
+++ b/src/theme/web3ModalCSS.tsx
@@ -11,5 +11,57 @@ export const web3ModalCSS = css`
     border-color: ${(props) => props.theme.modalStyle.content.borderColor};
     border-radius: ${(props) => props.theme.modalStyle.content.borderRadius};
     box-shadow: ${(props) => props.theme.modalStyle.content.boxShadow};
+    max-width: 350px;
+    padding: ${(props) => props.theme.cards.paddingVertical}
+      ${(props) => props.theme.cards.paddingHorizontal};
+  }
+
+  .web3modal-provider-wrapper {
+    border-radius: 4px;
+    border: solid 1px ${(props) => props.theme.colors.lightGrey};
+    padding: 0;
+    margin: 0 0 8px 0;
+
+    .web3modal-provider-container {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      padding: 12px;
+
+      .web3modal-provider-icon {
+        flex-grow: 0;
+        height: auto;
+        width: 28px;
+      }
+
+      .web3modal-provider-name {
+        color: #000;
+        font-family: ${(props) => props.theme.fonts.fontFamily};
+        font-size: 17px;
+        font-weight: 600;
+        line-height: 1;
+        margin: 0 0 0 12px;
+        padding: 0;
+        text-align: left;
+      }
+
+      .web3modal-provider-description {
+        display: none;
+      }
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    &:hover {
+      background-color: rgba(0, 156, 180, 0.1);
+      border: solid 1px ${(props) => props.theme.colors.primary};
+
+      .web3modal-provider-container {
+        background-color: transparent;
+      }
+    }
   }
 `

--- a/src/theme/web3ModalCSS.tsx
+++ b/src/theme/web3ModalCSS.tsx
@@ -11,9 +11,23 @@ export const web3ModalCSS = css`
     border-color: ${(props) => props.theme.modalStyle.content.borderColor};
     border-radius: ${(props) => props.theme.modalStyle.content.borderRadius};
     box-shadow: ${(props) => props.theme.modalStyle.content.boxShadow};
+    margin: 0;
     max-width: 350px;
-    padding: ${(props) => props.theme.cards.paddingVertical}
-      ${(props) => props.theme.cards.paddingHorizontal};
+    padding-bottom: 50px;
+    padding-left: ${(props) => props.theme.cards.paddingHorizontal};
+    padding-right: ${(props) => props.theme.cards.paddingHorizontal};
+    padding-top: ${(props) => props.theme.cards.paddingVertical};
+
+    &::before {
+      color: ${(props) => props.theme.colors.darkBlue};
+      content: 'Connect A Wallet';
+      font-family: ${(props) => props.theme.fonts.fontFamily};
+      font-size: 22px;
+      font-weight: 400;
+      line-height: 1.2;
+      margin: 0 0 25px;
+      text-align: left;
+    }
   }
 
   .web3modal-provider-wrapper {
@@ -28,6 +42,7 @@ export const web3ModalCSS = css`
       flex-direction: row;
       justify-content: flex-start;
       padding: 12px;
+      transition: all 0.15s linear;
 
       .web3modal-provider-icon {
         flex-grow: 0;
@@ -41,7 +56,7 @@ export const web3ModalCSS = css`
         font-size: 17px;
         font-weight: 600;
         line-height: 1;
-        margin: 0 0 0 12px;
+        margin: 4px 0 0 12px;
         padding: 0;
         text-align: left;
       }

--- a/src/theme/web3ModalCSS.tsx
+++ b/src/theme/web3ModalCSS.tsx
@@ -1,22 +1,78 @@
 import { css } from 'styled-components'
 
+const MODAL_HEIGHT = '226px'
+const MODAL_WIDTH = '350px'
+const X_DIMENSIONS = '20px'
+
 export const web3ModalCSS = css`
   .web3modal-modal-lightbox {
     background-color: ${(props) => props.theme.modalStyle.overlay.backgroundColor};
     z-index: ${(props) => props.theme.modalStyle.overlay.zIndex};
   }
 
+  .web3modal-modal-container {
+    align-items: center;
+    display: block;
+    height: 100vh;
+    padding: 0;
+    position: relative;
+    width: 100vw;
+
+    .web3modal-modal-hitbox::before {
+      color: ${(props) => props.theme.colors.darkBlue};
+      content: '';
+      background: url(data:image/svg+xml;base64,PHN2ZwogICAgaGVpZ2h0PSIyMCIKICAgIHZpZXdCb3g9IjAgMCAyMCAyMCIKICAgIHdpZHRoPSIyMCIKICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICA+CiAgICA8cGF0aCBkPSJNMCAwaDIwdjIwSDB6IiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIC8+CiAgICA8cGF0aAogICAgICBkPSJNMTEuMTMgMTBsNi42MzMgNi42MzJhLjguOCAwIDAgMS0xLjEzMiAxLjEzMUwxMCAxMS4xM2wtNi42MzUgNi42MzJhLjguOCAwIDAgMS0xLjEzMi0xLjEzMkw4Ljg2NiAxMCAyLjIzMyAzLjM2NWEuOC44IDAgMCAxIDEuMTMyLTEuMTMyTDEwIDguODY2bDYuNjMzLTYuNjMzYS44LjggMCAwIDEgMS4xMzIgMS4xMzJMMTEuMTMgMTB6IgogICAgICBmaWxsPSIjMDAxNDI4IgogICAgICBmaWxsLXJ1bGU9ImV2ZW5vZGQiCiAgICAvPgogIDwvc3ZnPg==);
+      cursor: pointer;
+      font-family: ${(props) => props.theme.fonts.fontFamily};
+      font-size: 22px;
+      height: ${X_DIMENSIONS};
+      left: 50%;
+      position: absolute;
+      top: 50%;
+      transform: translateX(
+          calc(
+            -50% + (
+                ${MODAL_WIDTH} - ${(props) => props.theme.cards.paddingHorizontal} * 2 -
+                  ${X_DIMENSIONS} / 2
+              ) / 2
+          )
+        )
+        translateY(
+          calc(
+            -50% - (
+                ${MODAL_HEIGHT} - ${(props) => props.theme.cards.paddingVertical} * 2 -
+                  ${X_DIMENSIONS} / 2
+              ) / 2
+          )
+        );
+      width: ${X_DIMENSIONS};
+      z-index: 150;
+    }
+  }
+
   .web3modal-modal-card {
+    align-items: flex-start;
     background-color: ${(props) => props.theme.modalStyle.content.backgroundColor};
     border-color: ${(props) => props.theme.modalStyle.content.borderColor};
     border-radius: ${(props) => props.theme.modalStyle.content.borderRadius};
     box-shadow: ${(props) => props.theme.modalStyle.content.boxShadow};
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    height: ${MODAL_HEIGHT};
+    left: 50%;
     margin: 0;
-    max-width: 350px;
+    max-width: 100%;
+    overflow: hidden;
     padding-bottom: 50px;
     padding-left: ${(props) => props.theme.cards.paddingHorizontal};
     padding-right: ${(props) => props.theme.cards.paddingHorizontal};
     padding-top: ${(props) => props.theme.cards.paddingVertical};
+    position: absolute;
+    top: 50%;
+    transform: translateX(-50%) translateY(-50%);
+    width: ${MODAL_WIDTH};
+    z-index: 10;
 
     &::before {
       color: ${(props) => props.theme.colors.darkBlue};

--- a/src/theme/web3ModalCSS.tsx
+++ b/src/theme/web3ModalCSS.tsx
@@ -18,35 +18,43 @@ export const web3ModalCSS = css`
     position: relative;
     width: 100vw;
 
-    .web3modal-modal-hitbox::before {
-      color: ${(props) => props.theme.colors.darkBlue};
-      content: '';
-      background: url(data:image/svg+xml;base64,PHN2ZwogICAgaGVpZ2h0PSIyMCIKICAgIHZpZXdCb3g9IjAgMCAyMCAyMCIKICAgIHdpZHRoPSIyMCIKICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICA+CiAgICA8cGF0aCBkPSJNMCAwaDIwdjIwSDB6IiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIC8+CiAgICA8cGF0aAogICAgICBkPSJNMTEuMTMgMTBsNi42MzMgNi42MzJhLjguOCAwIDAgMS0xLjEzMiAxLjEzMUwxMCAxMS4xM2wtNi42MzUgNi42MzJhLjguOCAwIDAgMS0xLjEzMi0xLjEzMkw4Ljg2NiAxMCAyLjIzMyAzLjM2NWEuOC44IDAgMCAxIDEuMTMyLTEuMTMyTDEwIDguODY2bDYuNjMzLTYuNjMzYS44LjggMCAwIDEgMS4xMzIgMS4xMzJMMTEuMTMgMTB6IgogICAgICBmaWxsPSIjMDAxNDI4IgogICAgICBmaWxsLXJ1bGU9ImV2ZW5vZGQiCiAgICAvPgogIDwvc3ZnPg==);
-      cursor: pointer;
-      font-family: ${(props) => props.theme.fonts.fontFamily};
-      font-size: 22px;
-      height: ${X_DIMENSIONS};
-      left: 50%;
+    .web3modal-modal-hitbox {
+      bottom: 0;
+      left: 0;
       position: absolute;
-      top: 50%;
-      transform: translateX(
-          calc(
-            -50% + (
-                ${MODAL_WIDTH} - ${(props) => props.theme.cards.paddingHorizontal} * 2 -
-                  ${X_DIMENSIONS} / 2
-              ) / 2
+      right: 0;
+      top: 0;
+
+      &::before {
+        color: ${(props) => props.theme.colors.darkBlue};
+        content: '';
+        background: url(data:image/svg+xml;base64,PHN2ZwogICAgaGVpZ2h0PSIyMCIKICAgIHZpZXdCb3g9IjAgMCAyMCAyMCIKICAgIHdpZHRoPSIyMCIKICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICA+CiAgICA8cGF0aCBkPSJNMCAwaDIwdjIwSDB6IiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiIC8+CiAgICA8cGF0aAogICAgICBkPSJNMTEuMTMgMTBsNi42MzMgNi42MzJhLjguOCAwIDAgMS0xLjEzMiAxLjEzMUwxMCAxMS4xM2wtNi42MzUgNi42MzJhLjguOCAwIDAgMS0xLjEzMi0xLjEzMkw4Ljg2NiAxMCAyLjIzMyAzLjM2NWEuOC44IDAgMCAxIDEuMTMyLTEuMTMyTDEwIDguODY2bDYuNjMzLTYuNjMzYS44LjggMCAwIDEgMS4xMzIgMS4xMzJMMTEuMTMgMTB6IgogICAgICBmaWxsPSIjMDAxNDI4IgogICAgICBmaWxsLXJ1bGU9ImV2ZW5vZGQiCiAgICAvPgogIDwvc3ZnPg==);
+        cursor: pointer;
+        font-family: ${(props) => props.theme.fonts.fontFamily};
+        font-size: 22px;
+        height: ${X_DIMENSIONS};
+        left: 50%;
+        position: absolute;
+        top: 50%;
+        transform: translateX(
+            calc(
+              -50% + (
+                  ${MODAL_WIDTH} - ${(props) => props.theme.cards.paddingHorizontal} * 2 -
+                    ${X_DIMENSIONS} / 2
+                ) / 2
+            )
           )
-        )
-        translateY(
-          calc(
-            -50% - (
-                ${MODAL_HEIGHT} - ${(props) => props.theme.cards.paddingVertical} * 2 -
-                  ${X_DIMENSIONS} / 2
-              ) / 2
-          )
-        );
-      width: ${X_DIMENSIONS};
-      z-index: 150;
+          translateY(
+            calc(
+              -50% - (
+                  ${MODAL_HEIGHT} - ${(props) => props.theme.cards.paddingVertical} * 2 -
+                    ${X_DIMENSIONS} / 2
+                ) / 2
+            )
+          );
+        width: ${X_DIMENSIONS};
+        z-index: 150;
+      }
     }
   }
 


### PR DESCRIPTION
Closes #178 
Related to #212 

Design's here: https://zpl.io/aMOdXk3

**A few notes about this:**

- It's not currently possible to modify the layout or functionality of _web3Modal_ in any officially supported way (https://github.com/Web3Modal/web3modal/issues/44), nor it's simple to do it in any unofficially supported way...
- ... but anyways I added some CSS to make it look more like it looks in the design.
- I used the wallet icons provided by the plugin. I think that - while not exactly the same seen on the design- they're fine.
- This is mostly related to #212, but - as stated- it's not possible to add a close button to this component. Addressing the "impossible to close" issue, it should be possible to close the modal by clicking the background overlay (which may not be obvious at first). I added some _hacky_ CSS to make having a "Close" button possible (and it seems to work), but be warned that this is kind of not future proof... Any unexpected modifications to the modal window's width or height could mess up the button's location. I think this is OK for now, but have in mind that it's far from perfect and eventually it could be done better when there's support for it.
- I also added some CSS to make the _"Wallet Connect"_ modal look a bit better. This is an external module and we have not mucho control over it, but it looks somewhat better now.

**It looked like this:**

![Screen Shot 2020-09-09 at 16 33 57](https://user-images.githubusercontent.com/4015436/92644837-53ae6b80-f2ba-11ea-92a7-b90d9b85b401.png)

**And it should look like this now:**

![Sep-09-2020 16-07-27](https://user-images.githubusercontent.com/4015436/92645398-28784c00-f2bb-11ea-8bf0-0319389aba1f.gif)

![Sep-09-2020 16-07-41](https://user-images.githubusercontent.com/4015436/92645227-e4854700-f2ba-11ea-94eb-4497bc50bfde.gif)
