### PR TITLE
 Add Edit Partition to Split Position

### DIFF
--- a/src/components/modals/EditPartitionModal/index.tsx
+++ b/src/components/modals/EditPartitionModal/index.tsx
@@ -118,17 +118,18 @@ interface EditPartitionModalProps extends ModalProps {
   outcomes: Array<any>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   theme?: any
+  onSave: (numberedOutcomes: Array<Array<OutcomeProps>>) => void
 }
 
 const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
-  const { onRequestClose, outcomes, theme, ...restProps } = props
+  const { onRequestClose, onSave, outcomes, theme, ...restProps } = props
   const dragOverClass = 'dragOver'
   const draggingClass = 'isDragging'
   const placeholderOutcomeId = 'placeholderOutcome'
   const outcomesByRow = '13'
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [allCollections, setAllCollections] = useState<any>([])
+  const [allCollections, setAllCollections] = useState<Array<Array<OutcomeProps>>>([])
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [newCollection, setNewCollection] = useState<any>([])
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -144,7 +145,11 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
 
   const removeOutcomeFromCollection = useCallback(
     (collectionIndex: number, outcomeIndex: number) => {
-      setAvailableOutcomes([...availableOutcomes, allCollections[collectionIndex][outcomeIndex]])
+      setAvailableOutcomes(
+        [...availableOutcomes, allCollections[collectionIndex][outcomeIndex]].sort((a, b) =>
+          a.value > b.value ? 1 : -1
+        )
+      )
 
       allCollections[collectionIndex].splice(outcomeIndex, 1)
 
@@ -203,7 +208,11 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
 
   const addOutcomeToNewCollection = useCallback(
     (outcomeIndex: number) => {
-      setNewCollection([...newCollection, availableOutcomes[outcomeIndex]])
+      setNewCollection(
+        [...newCollection, availableOutcomes[outcomeIndex]].sort((a, b) =>
+          a.value > b.value ? 1 : -1
+        )
+      )
       availableOutcomes.splice(outcomeIndex, 1)
     },
     [newCollection, availableOutcomes]
@@ -211,7 +220,11 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
 
   const removeOutcomeFromNewCollection = useCallback(
     (outcomeIndex: number) => {
-      setAvailableOutcomes([...availableOutcomes, newCollection[outcomeIndex]])
+      setAvailableOutcomes(
+        [...availableOutcomes, newCollection[outcomeIndex]].sort((a, b) =>
+          a.value > b.value ? 1 : -1
+        )
+      )
       newCollection.splice(outcomeIndex, 1)
     },
     [newCollection, availableOutcomes]
@@ -223,12 +236,16 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
   }, [newCollection, allCollections])
 
   const addAllAvailableOutcomesToNewCollection = useCallback(() => {
-    setNewCollection([...newCollection, ...availableOutcomes])
+    setNewCollection(
+      [...newCollection, ...availableOutcomes].sort((a, b) => (a.value > b.value ? 1 : -1))
+    )
     availableOutcomes.length = 0
   }, [availableOutcomes, newCollection])
 
   const clearOutcomesFromNewCollection = useCallback(() => {
-    setAvailableOutcomes([...availableOutcomes, ...newCollection])
+    setAvailableOutcomes(
+      [...availableOutcomes, ...newCollection].sort((a, b) => (a.value > b.value ? 1 : -1))
+    )
     newCollection.length = 0
   }, [availableOutcomes, newCollection])
 
@@ -242,14 +259,20 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
       })
     })
 
-    setAvailableOutcomes([...availableOutcomes, ...newAvailableOutcomes])
+    setAvailableOutcomes(
+      [...availableOutcomes, ...newAvailableOutcomes].sort((a, b) => (a.value > b.value ? 1 : -1))
+    )
     allCollections.length = 0
   }, [allCollections, availableOutcomes])
 
   const removeCollection = useCallback(
     (collectionIndex: number) => {
-      setAvailableOutcomes([...availableOutcomes, ...allCollections[collectionIndex]])
-      allCollections[collectionIndex].length = 0
+      setAvailableOutcomes(
+        [...availableOutcomes, ...allCollections[collectionIndex]].sort((a, b) =>
+          a.value > b.value ? 1 : -1
+        )
+      )
+      allCollections.splice(collectionIndex, 1)
       setAllCollections([
         ...allCollections.filter((collection: Array<OutcomeProps>) => collection.length > 0),
       ])
@@ -257,7 +280,9 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
     [availableOutcomes, allCollections]
   )
 
-  const onSave = onRequestClose
+  const onSubmit = () => {
+    onSave(allCollections)
+  }
 
   const onReset = useCallback(() => {
     setAllCollections([...outcomes])
@@ -447,7 +472,7 @@ const PartitionModal: React.FC<EditPartitionModalProps> = (props) => {
         <ButtonReset buttonType={ButtonType.danger} onClick={onReset}>
           Reset
         </ButtonReset>
-        <Button disabled={disableButton} onClick={onSave}>
+        <Button disabled={disableButton} onClick={onSubmit}>
           Save
         </Button>
       </ButtonContainer>

--- a/src/components/splitPosition/PositionPreview/index.tsx
+++ b/src/components/splitPosition/PositionPreview/index.tsx
@@ -10,13 +10,13 @@ import {
 import { TitleValue } from 'components/text/TitleValue'
 import { useCollateral } from 'hooks/useCollateral'
 import { GetPosition_position } from 'types/generatedGQL'
-import { positionString, trivialPartition } from 'util/tools'
+import { positionString } from 'util/tools'
 import { SplitFromType, Token } from 'util/types'
 
 interface Props {
   amount: BigNumber
   conditionId: string
-  outcomeSlotCount: number
+  partition: Maybe<BigNumber[]>
   position: Maybe<GetPosition_position>
   selectedCollateral: Token
   splitFrom: SplitFromType
@@ -29,7 +29,7 @@ const StripedListStyled = styled(StripedList)`
 export const PositionPreview = ({
   amount,
   conditionId,
-  outcomeSlotCount,
+  partition,
   position,
   selectedCollateral,
   splitFrom,
@@ -45,14 +45,14 @@ export const PositionPreview = ({
       return []
     }
 
-    if (splitFromCollateral) {
-      return trivialPartition(outcomeSlotCount).map((indexSet) => {
+    if (splitFromCollateral && partition && partition.length > 0) {
+      return partition.map((indexSet) => {
         return positionString([conditionId], [indexSet], amount, selectedCollateral)
       })
     }
 
-    if (position && positionCollateral) {
-      return trivialPartition(outcomeSlotCount).map((indexSet) => {
+    if (position && positionCollateral && partition && partition.length > 0) {
+      return partition.map((indexSet) => {
         return positionString(
           [...position.conditionIds, conditionId],
           [...[position.indexSets], indexSet],
@@ -65,7 +65,7 @@ export const PositionPreview = ({
   }, [
     amount,
     conditionId,
-    outcomeSlotCount,
+    partition,
     position,
     positionCollateral,
     selectedCollateral,

--- a/src/hooks/usePositions.tsx
+++ b/src/hooks/usePositions.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/react-hooks'
-import uniqBy from 'lodash.uniqby'
+import lodashUniqBy from 'lodash.uniqby'
 import React from 'react'
 
 import { Web3ContextStatus, useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
@@ -78,7 +78,7 @@ export const usePositions = (options: OptionsToSearch) => {
       const positionListData = marshalPositionListData(positionsData.positions, userData?.user)
 
       const fetchUserBalanceWithDecimals = async () => {
-        const uniqueCollateralTokens = uniqBy(positionListData, 'collateralToken')
+        const uniqueCollateralTokens = lodashUniqBy(positionListData, 'collateralToken')
 
         const collateralTokensPromises = uniqueCollateralTokens.map(async (position: Position) => {
           const { collateralToken } = position

--- a/src/pages/SplitPosition/index.tsx
+++ b/src/pages/SplitPosition/index.tsx
@@ -55,14 +55,11 @@ export const SplitPosition = () => {
     [status, CTService, connect]
   )
 
-  // TODO Fix this
   useEffect(() => {
-    if (!collateralToken) {
-      logger.error(`Collateral ${collateral} doesn't exist`)
-    } else {
+    if (collateralToken) {
       setIsLoading(false)
     }
-  }, [collateralToken, collateral])
+  }, [collateralToken])
 
   return (
     <ConditionProvider>


### PR DESCRIPTION
Closes #67 
Closes #66 

- Allow to edit a partition, add or remove a collection
- Allways will generate the partition from the outcomeSlotCount, not from the collections of the condition
- The user, will need to add at least two collections, and all the outcomes (Please @lmcorbalan check this)
- Fix the comments in the original issues related to the sort, and how the circles are named.

![Peek 11-09-2020 18-42](https://user-images.githubusercontent.com/1144028/92975471-b6406c80-f45e-11ea-9967-1f1233e5124a.gif)

