### PR TITLE
(fix) condition id order

### DIFF
--- a/src/pages/ConditionDetails/Contents.tsx
+++ b/src/pages/ConditionDetails/Contents.tsx
@@ -97,10 +97,6 @@ export const Contents: React.FC<Props> = ({ condition }) => {
     >
       <Row marginBottomXL>
         <TitleValue
-          title="Condition Type"
-          value={isConditionFromOmen ? ConditionType.omen : ConditionType.custom}
-        />
-        <TitleValue
           title="Condition Id"
           value={
             <>
@@ -108,6 +104,10 @@ export const Contents: React.FC<Props> = ({ condition }) => {
               <ButtonCopy value={conditionId} />
             </>
           }
+        />
+        <TitleValue
+          title="Condition Type"
+          value={isConditionFromOmen ? ConditionType.omen : ConditionType.custom}
         />
         <TitleValue
           title="Status"


### PR DESCRIPTION
No related issue.

Just a minor nitpick: moved the _"Condition ID"_ data to the first position on _"Condition Details"_. It is the only place where a Condition / Position ID it's not the first item.