### PR TITLE
Custom handler for cell components

### DIFF
--- a/src/components/common/TokenIcon/index.tsx
+++ b/src/components/common/TokenIcon/index.tsx
@@ -114,14 +114,15 @@ const getTokenData = (symbol: string): Array<any> => {
 
 interface Props {
   symbol: string
+  onClick?: () => void
 }
 
 export const TokenIcon: React.FC<Props> = (props) => {
-  const { symbol, ...restProps } = props
+  const { onClick, symbol, ...restProps } = props
   const data = getTokenData(symbol)
 
   return (
-    <Wrapper {...restProps}>
+    <Wrapper onClick={onClick} {...restProps}>
       {data.length > 0 ? (
         <Icon>{data[0].icon}</Icon>
       ) : (

--- a/src/pages/ConditionsList/index.tsx
+++ b/src/pages/ConditionsList/index.tsx
@@ -116,7 +116,7 @@ export const ConditionsList: React.FC = () => {
     {
       // eslint-disable-next-line react/display-name
       cell: (row: Conditions_conditions) => (
-        <CellHash onClick={handleRowClick} value={row.oracle} />
+        <CellHash onClick={() => handleRowClick(row)} value={row.oracle} />
       ),
       name: 'Reporting Address / Oracle',
       selector: 'oracle',
@@ -125,7 +125,7 @@ export const ConditionsList: React.FC = () => {
     {
       // eslint-disable-next-line react/display-name
       cell: (row: Conditions_conditions) => (
-        <CellHash onClick={handleRowClick} value={row.questionId} />
+        <CellHash onClick={() => handleRowClick(row)} value={row.questionId} />
       ),
       name: 'Question Id',
       selector: 'questionId',
@@ -147,9 +147,13 @@ export const ConditionsList: React.FC = () => {
       // eslint-disable-next-line react/display-name
       cell: (row: Conditions_conditions) =>
         row.resolved ? (
-          <Pill type={PillTypes.primary}>Resolved</Pill>
+          <Pill onClick={() => handleRowClick(row)} type={PillTypes.primary}>
+            Resolved
+          </Pill>
         ) : (
-          <Pill type={PillTypes.open}>Open</Pill>
+          <Pill onClick={() => handleRowClick(row)} type={PillTypes.open}>
+            Open
+          </Pill>
         ),
       sortFunction: (a: Conditions_conditions, b: Conditions_conditions) => {
         const valA = a.resolved ? 2 : 1

--- a/src/pages/PositionsList/index.tsx
+++ b/src/pages/PositionsList/index.tsx
@@ -128,7 +128,10 @@ export const PositionsList = () => {
         {
           // eslint-disable-next-line react/display-name
           cell: (row: PositionWithUserBalanceWithDecimals) => (
-            <span {...(row.userBalanceWithDecimals ? { title: row.userBalance.toString() } : {})}>
+            <span
+              onClick={() => handleRowClick(row)}
+              {...(row.userBalanceWithDecimals ? { title: row.userBalance.toString() } : {})}
+            >
               {row.userBalanceWithDecimals}
             </span>
           ),
@@ -139,7 +142,7 @@ export const PositionsList = () => {
         },
       ])
     }
-  }, [status, buildMenuForRow])
+  }, [status, buildMenuForRow, handleRowClick])
 
   const getColumns = useCallback(() => {
     // If you move this outside of the useCallback, can cause performance issues as a dep of this useCallback
@@ -160,7 +163,12 @@ export const PositionsList = () => {
           try {
             const token = networkConfig && networkConfig.getTokenFromAddress(row.collateralToken)
             // Please don't delete this because the tests will explode
-            return <TokenIcon symbol={(token && token.symbol) || ''} />
+            return (
+              <TokenIcon
+                onClick={() => handleRowClick(row)}
+                symbol={(token && token.symbol) || ''}
+              />
+            )
           } catch (error) {
             logger.error(error)
             return row.collateralToken


### PR DESCRIPTION
Closes #248 

This should be working by default, and as an exception needs to use `ignoreRowClick` to not use `onRowClicked` but it doesn't seem to be configured in that way or any option disabling it, so I just added a handler that includes the row information.