### PR TITLE
Fix ordering and jsx interpolation in modal after split

### DIFF
--- a/src/components/splitPosition/DisplayTablePosition/index.tsx
+++ b/src/components/splitPosition/DisplayTablePosition/index.tsx
@@ -50,7 +50,7 @@ export const DisplayTablePositions = ({
         maxWidth: '250px',
         minWidth: '250px',
         name: 'Position Id',
-        selector: 'id',
+        selector: (row: PositionIdsArray) => row.positionId,
         sortable: true,
       },
       {

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -351,11 +351,15 @@ export const Form = ({
         <Modal
           isOpen={status.isSuccess()}
           onRequestClose={clearComponent}
-          subTitle={`Positions were successfully split from ${(
-            <span title={conditionIdToPreviewShow}>
-              {truncateStringInTheMiddle(conditionIdToPreviewShow, 8, 6)}
-            </span>
-          )}.`}
+          subTitle={
+            <>
+              Positions were successfully split from{' '}
+              <span title={conditionIdToPreviewShow}>
+                {truncateStringInTheMiddle(conditionIdToPreviewShow, 8, 6)}
+              </span>
+              .
+            </>
+          }
           title={'Split Positions'}
         >
           {splitPositionsTable}


### PR DESCRIPTION
Closes #277 

If this is solved in another pull request, just ignore. 