### PR TITLE
Wrap and unwrap modals: cannot enter a value which starts with 0. into the Amount field 

### DIFF
--- a/src/components/form/BigNumberInputWrapper/index.tsx
+++ b/src/components/form/BigNumberInputWrapper/index.tsx
@@ -82,7 +82,7 @@ export const BigNumberInputWrapper: React.FC<Props> = (props) => {
         renderInput={(props: unknown) => {
           return <Textfield disabled={disabled} {...props} />
         }}
-        value={value && !value.isZero() ? value.toString() : ''}
+        value={value ? value.toString() : ''}
       />
       {tokenSymbol && <TokenSymbol>{tokenSymbol}</TokenSymbol>}
     </Wrapper>


### PR DESCRIPTION
Closes #255 

The BigNumberInput, is a common component used through all the application, so we need to check every section is working properly.