### PR TITLE
Implement default sort order for grid lines on the Conditions pages

### DIFF
--- a/src/components/modals/SelectConditionModal/index.tsx
+++ b/src/components/modals/SelectConditionModal/index.tsx
@@ -78,7 +78,7 @@ export const SelectConditionModal: React.FC<Props> = (props) => {
     () => [
       {
         name: 'Condition Id',
-        selector: 'id',
+        selector: 'createTimestamp',
         sortable: true,
         // eslint-disable-next-line react/display-name
         cell: (row: Conditions_conditions) => truncateStringInTheMiddle(row.id, 8, 6),

--- a/src/hooks/useConditions.tsx
+++ b/src/hooks/useConditions.tsx
@@ -35,7 +35,10 @@ export const useConditions = (options: OptionsToSearch) => {
 
   const query = buildQueryConditions(queryOptions)
 
-  const { data, error, loading } = useQuery<Conditions>(query, { variables: queryOptions })
+  const { data, error, loading } = useQuery<Conditions>(query, {
+    variables: queryOptions,
+    fetchPolicy: 'no-cache',
+  })
 
   return {
     data,

--- a/src/hooks/usePositions.tsx
+++ b/src/hooks/usePositions.tsx
@@ -74,6 +74,7 @@ export const usePositions = (options: OptionsToSearch) => {
     refetch: refetchUserPositions,
   } = useQuery<UserWithPositions>(UserWithPositionsQuery, {
     skip: !address,
+    fetchPolicy: 'no-cache',
     variables: {
       account: address,
     },

--- a/src/pages/ConditionsList/index.tsx
+++ b/src/pages/ConditionsList/index.tsx
@@ -110,7 +110,7 @@ export const ConditionsList: React.FC = () => {
         />
       ),
       name: 'Condition Id',
-      selector: 'id',
+      selector: 'createTimestamp',
       sortable: true,
     },
     {

--- a/src/queries/conditions.tsx
+++ b/src/queries/conditions.tsx
@@ -37,7 +37,7 @@ export const buildQueryConditions = (options: ConditionsListType = DEFAULT_OPTIO
 
   const query = gql`
       query Conditions ${variablesClause} {
-        conditions(first: 1000 ${whereClause}) {
+        conditions(first: 1000 ${whereClause} , orderBy: createTimestamp, orderDirection: desc) {
           id
           oracle
           questionId


### PR DESCRIPTION
Related to the issue #208 

This only fix the sort for the conditions, for the positions we need to wait until the issue https://github.com/gnosis/hg-subgraph/issues/19 could be fixed