### PR TITLE
(fix) modal title's line height

### DIFF
--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -22,7 +22,7 @@ const TitleText = styled.h2`
   flex-grow: 1;
   font-size: 22px;
   font-weight: 400;
-  line-height: 1;
+  line-height: 1.3;
   margin: 0;
   overflow: hidden;
   padding: 0 10px 0 0;

--- a/src/components/statusInfo/common.tsx
+++ b/src/components/statusInfo/common.tsx
@@ -6,7 +6,7 @@ export const Title = styled.h1<{ textAlign?: string }>`
   color: ${(props) => props.theme.colors.darkBlue};
   font-size: 22px;
   font-weight: 400;
-  line-height: 1;
+  line-height: 1.3;
   margin: 0;
   text-align: ${(props) => props.textAlign};
   text-transform: capitalize;


### PR DESCRIPTION
Closes #360 

I'm not able to reproduce the problem, but I suspect it has something to do with the `line-height` property's value, so I increased it.

I think that'll do it.