### PR TITLE
(fix) modal's title line height

### DIFF
--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -22,7 +22,6 @@ const TitleText = styled.h2`
   flex-grow: 1;
   font-size: 22px;
   font-weight: 400;
-  line-height: 1.3;
   margin: 0;
   overflow: hidden;
   padding: 0 10px 0 0;

--- a/src/components/statusInfo/common.tsx
+++ b/src/components/statusInfo/common.tsx
@@ -6,7 +6,6 @@ export const Title = styled.h1<{ textAlign?: string }>`
   color: ${(props) => props.theme.colors.darkBlue};
   font-size: 22px;
   font-weight: 400;
-  line-height: 1.3;
   margin: 0;
   text-align: ${(props) => props.textAlign};
   text-transform: capitalize;


### PR DESCRIPTION
Closes #360

I still can't reproduce the issue, but increased line height a little more.