### PR TITLE
Select Positions modal: not found search return all positions

### DIFF
--- a/src/components/modals/SelectPositionsModal/index.tsx
+++ b/src/components/modals/SelectPositionsModal/index.tsx
@@ -63,17 +63,17 @@ export const SelectPositionModal: React.FC<Props> = (props) => {
   const [positionIdToSearch, setPositionIdToSearch] = useState<string>('')
   const [positionIdToShow, setPositionIdToShow] = useState<string>('')
 
-  const debouncedHandler = useDebounceCallback((positionIdToSearch) => {
+  const debouncedHandlerPositionIdToSearch = useDebounceCallback((positionIdToSearch) => {
     setPositionIdToSearch(positionIdToSearch)
   }, 500)
 
-  const inputHandler = React.useCallback(
+  const onChangePositionId = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const { value } = event.currentTarget
       setPositionIdToShow(value)
-      debouncedHandler(value)
+      debouncedHandlerPositionIdToSearch(value)
     },
-    [debouncedHandler]
+    [debouncedHandlerPositionIdToSearch]
   )
 
   const { data, error, loading } = usePositions({
@@ -251,8 +251,8 @@ export const SelectPositionModal: React.FC<Props> = (props) => {
           <TableControls
             start={
               <Search
-                onChange={inputHandler}
-                placeholder="Search position id..."
+                onChange={onChangePositionId}
+                placeholder="Search by position id..."
                 value={positionIdToShow}
               />
             }

--- a/src/hooks/useWithToken.tsx
+++ b/src/hooks/useWithToken.tsx
@@ -57,6 +57,10 @@ export const useWithToken = <T extends WithAddress>(
             setLoading(false)
           }
         })
+    } else {
+      setLoading(true)
+      setDataWithToken([])
+      setLoading(false)
     }
 
     return () => {


### PR DESCRIPTION
The Select positions modal mixture the `data` query obtained from `usePositions` with aditional token information on `useWithToken`. When the `data` array provided is empty, the `setDataWithToken` useState will return all positions list.
To avoid this was added a `setDataWithToken([])` in case the searched parameter `data` is empty.

Closes #285 