### PR TITLE
Open single select position on click

### DIFF
--- a/src/components/form/SelectPositions/index.tsx
+++ b/src/components/form/SelectPositions/index.tsx
@@ -178,10 +178,11 @@ export const SelectPositions = ({
           <>
             {singlePosition ? (
               <TextfieldFetchableData
-                disabled={true}
                 error={!!errors.length}
                 isFetching={isLoading || balancesLoading}
+                onClick={() => setIsModalOpen(true)}
                 placeholder={'Please select a position...'}
+                readOnly
                 type="text"
                 value={positionsToDisplay.length ? positionsToDisplay[0] : ''}
               />


### PR DESCRIPTION
Closes #376 

In my opinion, is a kind of weird behavior to have when there is a button to open the modal, but also I think we should close (related to this) the issue #227, because there is no point in removing a position if you not going to select another, and for that, we have the modal. 

I've created this as a draft because I removed the disabled attribute on the input of single positions and it could allow us to move to that input without clicking and pasting text to it. And maybe UX-wise point of view #376 could be removed if is not valid or friendly.   