### PR TITLE
Fix Split Position unassigned collateralToken from a given positionId

### DIFF
--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -172,8 +172,8 @@ export const Form = ({
             collateral
           )
         } else if (splitFromPosition && position) {
-          collateral = position.collateralToken.id
-          const collectionId = position.collection.id
+          collateral = position.collateralToken?.id
+          const collectionId = position.collection?.id
           await splitPosition(collateral, collectionId, conditionId, partition, amount)
 
           positionIds = await CTService.getPositionsFromPartition(

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -172,11 +172,8 @@ export const Form = ({
             collateral
           )
         } else if (splitFromPosition && position) {
-          const {
-            collateralToken: { id: collateral },
-            collection: { id: collectionId },
-          } = position
-
+          collateral = position.collateralToken.id
+          const collectionId = position.collection.id
           await splitPosition(collateral, collectionId, conditionId, partition, amount)
 
           positionIds = await CTService.getPositionsFromPartition(

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -162,6 +162,7 @@ export const Form = ({
         setStatus(Remote.loading())
 
         let positionIds: PositionIdsArray[]
+        let collateralFromSplit: string = collateral
         if (splitFromCollateral) {
           await splitPosition(collateral, NULL_PARENT_ID, conditionId, partition, amount)
 
@@ -169,24 +170,29 @@ export const Form = ({
             partition,
             NULL_PARENT_ID,
             conditionId,
-            collateral
+            collateralFromSplit
           )
-        } else if (splitFromPosition && position) {
-          collateral = position.collateralToken?.id
-          const collectionId = position.collection?.id
-          await splitPosition(collateral, collectionId, conditionId, partition, amount)
+        } else if (
+          splitFromPosition &&
+          position &&
+          position.collateralToken &&
+          position.collection
+        ) {
+          collateralFromSplit = position.collateralToken.id
+          const collectionId = position.collection.id
+          await splitPosition(collateralFromSplit, collectionId, conditionId, partition, amount)
 
           positionIds = await CTService.getPositionsFromPartition(
             partition,
             collectionId,
             conditionId,
-            collateral
+            collateralFromSplit
           )
         } else {
           throw Error('Invalid split origin')
         }
 
-        setStatus(Remote.success({ positionIds, collateral }))
+        setStatus(Remote.success({ positionIds, collateral: collateralFromSplit }))
       } catch (err) {
         logger.error(err)
         setStatus(Remote.failure(err))


### PR DESCRIPTION
After split a position from a given position id, the constant set to alias from `collateral` is already an assinged constant. Typescript and linter are not warning about that because the alias comes with double asignation. Maybe could be reported to the linter.

Closes #361