### PR TITLE
(fix) broken "open in new tab" link

### DIFF
--- a/src/components/form/DisplayTablePosition/index.tsx
+++ b/src/components/form/DisplayTablePosition/index.tsx
@@ -33,7 +33,7 @@ export const DisplayTablePositions = (props: Props) => {
         // eslint-disable-next-line react/display-name
         cell: (row: PositionIdsArray) => {
           return (
-            <CellHash externalLink href={`positions/${row.positionId}`} value={row.positionId} />
+            <CellHash externalLink href={`/positions/${row.positionId}`} value={row.positionId} />
           )
         },
         maxWidth: '250px',

--- a/src/components/icons/ExternalLinkIcon.tsx
+++ b/src/components/icons/ExternalLinkIcon.tsx
@@ -19,22 +19,14 @@ export const ExternalLinkIcon: React.FC<{ className?: string }> = (props) => (
   <Wrapper
     className={`externalLinkIcon ${props.className}`}
     height="15"
-    viewBox="0 0 24 24"
+    viewBox="0 0 768 1024"
     width="15"
     xmlns="http://www.w3.org/2000/svg"
     {...props}
   >
-    <g fill="none" fillRule="evenodd">
-      <path d="M0 0H24V24H0z" />
-      <path
-        className="fill"
-        d="M20 20v-8c0-.552.448-1 1-1s1 .448 1 1v8c0 1.105-.895 2-2 2H4c-1.105 0-2-.895-2-2V4c0-1.105.895-2 2-2h8c.552 0 1 .448 1 1s-.448 1-1 1H4v16h16z"
-        fillRule="nonzero"
-      />
-      <path
-        className="fill"
-        d="M18.536 4H15.95c-.553 0-1-.448-1-1s.447-1 1-1h5c.276 0 .526.112.707.293.18.18.293.43.293.707v5c0 .552-.448 1-1 1-.553 0-1-.448-1-1V5.414l-9.243 9.243c-.39.39-1.024.39-1.414 0-.39-.39-.39-1.024 0-1.414L18.536 4z"
-      />
-    </g>
+    <path
+      className="fill"
+      d="M640 768H128V257.90599999999995L256 256V128H0v768h768V576H640V768zM384 128l128 128L320 448l128 128 192-192 128 128V128H384z"
+    />
   </Wrapper>
 )

--- a/src/components/table/CellHash/index.tsx
+++ b/src/components/table/CellHash/index.tsx
@@ -32,7 +32,7 @@ const ExternalLink = styled.a`
   align-items: center;
   display: flex;
   justify-content: center;
-  margin-left: 10px;
+  margin-left: 8px;
   text-decoration: none;
 `
 
@@ -63,7 +63,7 @@ export const CellHash: React.FC<Props> = (props) => {
       <ButtonCopy light value={value} />
       {externalLink && (
         <ExternalLink
-          href={`${window.location.protocol}//${window.location.hostname}${port}/#/${href}`}
+          href={`${window.location.protocol}//${window.location.hostname}${port}/#${href}`}
           target="_blank"
         >
           <ExternalLinkIcon />


### PR DESCRIPTION
Closes #387
Related to #395

It should be fixed now.