### PR TITLE
Position with 0 amount is displayed on the confirmation

### DIFF
--- a/src/services/conditionalTokens.ts
+++ b/src/services/conditionalTokens.ts
@@ -122,6 +122,11 @@ export class ConditionalTokensService {
 
       const balance = await this.balanceOf(positionId)
 
+      logger.info(`Position: ${positionId} with amount ${balance}`)
+
+      if (balance.isZero()) {
+        throw new Error(`This position id ${positionId} has balance zero.`)
+      }
       return { positionId, balance }
     })
     const partitions = await Promise.all(partitionsPromises)


### PR DESCRIPTION
- Throw error when split a position with balance zero

Closes #289 