### PR TITLE
[FE] Wrap/Unwrap: change 'Use Wallet Balance' to 'Use Position Balance'

### DIFF
--- a/src/components/modals/UnwrapModal/index.tsx
+++ b/src/components/modals/UnwrapModal/index.tsx
@@ -65,6 +65,7 @@ export const UnwrapModal: React.FC<Props> = (props) => {
           amount={amount}
           balance={maxBalance}
           decimals={decimals}
+          isFromAPosition
           max={maxBalance.toString()}
           onAmountChange={amountChangeHandler}
           onUseWalletBalance={useWalletHandler}

--- a/src/components/modals/WrapModal/index.tsx
+++ b/src/components/modals/WrapModal/index.tsx
@@ -57,6 +57,7 @@ export const WrapModal: React.FC<Props> = (props) => {
           amount={amount}
           balance={maxBalance}
           decimals={decimals}
+          isFromAPosition
           max={maxBalance.toString()}
           onAmountChange={amountChangeHandler}
           onUseWalletBalance={useWalletHandler}

--- a/src/pages/PositionDetails/Contents.tsx
+++ b/src/pages/PositionDetails/Contents.tsx
@@ -358,7 +358,9 @@ export const Contents = (props: Props) => {
                 <CollateralText>
                   <CollateralTextStrong>ERC1155:</CollateralTextStrong>{' '}
                   <CollateralTextAmount>
-                    {formatBigNumber(balanceERC1155, ERC1155Decimals)} {ERC1155Symbol}
+                    {!balanceERC1155.isZero()
+                      ? `${formatBigNumber(balanceERC1155, ERC1155Decimals)} ${ERC1155Symbol}`
+                      : 'None.'}
                   </CollateralTextAmount>
                 </CollateralText>
                 <CollateralWrapButton


### PR DESCRIPTION
Closes #319 

Now look like this
The `None` word is used for both

![Screenshot_20201005_171611](https://user-images.githubusercontent.com/1144028/95127528-7bb0b380-072e-11eb-8992-09716e8f70ea.png)

Wrap and unwrap texts now  says `Use Position Balance...`

![Screenshot_20201005_171651](https://user-images.githubusercontent.com/1144028/95127660-b87caa80-072e-11eb-8846-e6f284474d83.png)
![Screenshot_20201005_171701](https://user-images.githubusercontent.com/1144028/95127670-badf0480-072e-11eb-9408-d335efeb0ea2.png)
