### PR TITLE
(Fix) Status info window's width

### DIFF
--- a/src/components/buttons/ButtonSelect/index.tsx
+++ b/src/components/buttons/ButtonSelect/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import { ChevronDown } from 'components/icons/ChevronDown'
 
-const Wrapper = styled.div`
+const Wrapper = styled.button`
   align-items: center;
   background-color: ${(props) => props.theme.textField.backgroundColor};
   border-color: ${(props) => props.theme.textField.borderColor};

--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -26,7 +26,7 @@ const Wrapper = styled.div<{ isOpen: boolean; disabled: boolean }>`
   }
 `
 
-const Button = styled.button`
+const ButtonContainer = styled.div`
   background-color: transparent;
   border: none;
   display: block;
@@ -203,9 +203,9 @@ export const Dropdown: React.FC<Props> = (props) => {
       ref={node}
       {...restProps}
     >
-      <Button className="dropdownButton" onClick={onButtonClick}>
+      <ButtonContainer className="dropdownButton" onClick={onButtonClick}>
         {dropdownButtonContent}
-      </Button>
+      </ButtonContainer>
       <Items
         className="dropdownItems"
         dropdownDirection={dropdownDirection}

--- a/src/components/form/Amount/index.tsx
+++ b/src/components/form/Amount/index.tsx
@@ -1,5 +1,5 @@
 import { BigNumber } from 'ethers/utils'
-import React from 'react'
+import React, { InputHTMLAttributes } from 'react'
 
 import { BigNumberInputWrapper } from 'components/form/BigNumberInputWrapper'
 import { TitleControlButton } from 'components/pureStyledComponents/TitleControl'
@@ -7,12 +7,10 @@ import { TitleValue } from 'components/text/TitleValue'
 import { Web3ContextStatus, useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
 import { formatBigNumber } from 'util/tools'
 
-interface Props {
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   amount: BigNumber
-  autoFocus?: boolean
   balance: BigNumber
   decimals: number
-  disabled?: boolean
   isFromAPosition?: boolean
   max: string
   onAmountChange: (value: BigNumber) => void
@@ -29,6 +27,7 @@ export const Amount = ({
   isFromAPosition = false,
   max,
   onAmountChange,
+  onKeyUp,
   onUseWalletBalance,
   tokenSymbol,
 }: Props) => {
@@ -56,6 +55,7 @@ export const Amount = ({
           disabled={disabled}
           max={max}
           onChange={onAmountChange}
+          onKeyUp={onKeyUp}
           tokenSymbol={tokenSymbol}
           value={amount}
         />

--- a/src/components/form/BigNumberInputWrapper/index.tsx
+++ b/src/components/form/BigNumberInputWrapper/index.tsx
@@ -39,14 +39,15 @@ const TokenSymbol = styled.span`
 
 interface Props {
   autoFocus?: boolean
-  disabled?: boolean
   decimals?: number
-  onChange?: (n: BigNumber) => void
-  tokenSymbol?: string
-  value?: BigNumber
-  placeholder?: string
+  disabled?: boolean
   max?: string
   min?: string
+  onChange?: (n: BigNumber) => void
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void | undefined
+  placeholder?: string
+  tokenSymbol?: string
+  value?: BigNumber
 }
 
 export const BigNumberInputWrapper: React.FC<Props> = (props) => {

--- a/src/components/modals/UnwrapModal/index.tsx
+++ b/src/components/modals/UnwrapModal/index.tsx
@@ -55,25 +55,31 @@ export const UnwrapModal: React.FC<Props> = (props) => {
 
   const isSubmitDisabled = amount.isZero()
 
-  const unWrap = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    const unWrapValues = {
-      amount,
-      address: CTService.address,
-      positionId,
-    }
+  const unWrap = useCallback(
+    (
+      e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>
+    ) => {
+      const unWrapValues = {
+        amount,
+        address: CTService.address,
+        positionId,
+      }
 
-    if (isSubmitDisabled) return
+      if (isSubmitDisabled) return
 
-    onUnWrap(unWrapValues)
+      onUnWrap(unWrapValues)
 
-    if (onRequestClose) onRequestClose(e)
-  }
+      if (onRequestClose) onRequestClose(e)
+    },
+    [CTService.address, amount, isSubmitDisabled, onRequestClose, onUnWrap, positionId]
+  )
 
-  const onPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') unWrap(e)
-  }
+  const onPressEnter = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') unWrap(e)
+    },
+    [unWrap]
+  )
 
   return (
     <Modal

--- a/src/components/modals/UnwrapModal/index.tsx
+++ b/src/components/modals/UnwrapModal/index.tsx
@@ -53,6 +53,28 @@ export const UnwrapModal: React.FC<Props> = (props) => {
     }
   }, [maxBalance])
 
+  const isSubmitDisabled = amount.isZero()
+
+  const unWrap = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    const unWrapValues = {
+      amount,
+      address: CTService.address,
+      positionId,
+    }
+
+    if (isSubmitDisabled) return
+
+    onUnWrap(unWrapValues)
+
+    if (onRequestClose) onRequestClose(e)
+  }
+
+  const onPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') unWrap(e)
+  }
+
   return (
     <Modal
       onRequestClose={onRequestClose}
@@ -69,23 +91,13 @@ export const UnwrapModal: React.FC<Props> = (props) => {
           isFromAPosition
           max={maxBalance.toString()}
           onAmountChange={amountChangeHandler}
+          onKeyUp={onPressEnter}
           onUseWalletBalance={useWalletHandler}
           tokenSymbol={tokenSymbol}
         />
       </FirstRow>
       <ButtonContainerStyled>
-        <Button
-          disabled={amount.isZero()}
-          onClick={(e) => {
-            const wrapValues = {
-              amount,
-              address: CTService.address,
-              positionId,
-            }
-            onUnWrap(wrapValues)
-            if (onRequestClose) onRequestClose(e)
-          }}
-        >
+        <Button disabled={isSubmitDisabled} onClick={unWrap}>
           Unwrap
         </Button>
       </ButtonContainerStyled>

--- a/src/components/modals/WrapModal/index.tsx
+++ b/src/components/modals/WrapModal/index.tsx
@@ -47,25 +47,31 @@ export const WrapModal: React.FC<Props> = (props) => {
 
   const isSubmitDisabled = amount.isZero()
 
-  const wrap = (
-    e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>
-  ) => {
-    const wrapValues = {
-      amount,
-      address: WrapperService.address,
-      positionId,
-    }
+  const wrap = useCallback(
+    (
+      e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>
+    ) => {
+      const wrapValues = {
+        amount,
+        address: WrapperService.address,
+        positionId,
+      }
 
-    if (isSubmitDisabled) return
+      if (isSubmitDisabled) return
 
-    onWrap(wrapValues)
+      onWrap(wrapValues)
 
-    if (onRequestClose) onRequestClose(e)
-  }
+      if (onRequestClose) onRequestClose(e)
+    },
+    [WrapperService.address, amount, isSubmitDisabled, onRequestClose, onWrap, positionId]
+  )
 
-  const onPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') wrap(e)
-  }
+  const onPressEnter = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') wrap(e)
+    },
+    [wrap]
+  )
 
   return (
     <Modal

--- a/src/components/modals/WrapModal/index.tsx
+++ b/src/components/modals/WrapModal/index.tsx
@@ -45,6 +45,28 @@ export const WrapModal: React.FC<Props> = (props) => {
     }
   }, [maxBalance])
 
+  const isSubmitDisabled = amount.isZero()
+
+  const wrap = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent> | React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    const wrapValues = {
+      amount,
+      address: WrapperService.address,
+      positionId,
+    }
+
+    if (isSubmitDisabled) return
+
+    onWrap(wrapValues)
+
+    if (onRequestClose) onRequestClose(e)
+  }
+
+  const onPressEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') wrap(e)
+  }
+
   return (
     <Modal
       onRequestClose={onRequestClose}
@@ -61,24 +83,13 @@ export const WrapModal: React.FC<Props> = (props) => {
           isFromAPosition
           max={maxBalance.toString()}
           onAmountChange={amountChangeHandler}
+          onKeyUp={onPressEnter}
           onUseWalletBalance={useWalletHandler}
           tokenSymbol={tokenSymbol}
         />
       </FirstRow>
       <ButtonContainerStyled>
-        <Button
-          disabled={amount.isZero()}
-          onClick={(e) => {
-            const wrapValues = {
-              amount,
-              address: WrapperService.address,
-              positionId,
-            }
-            onWrap(wrapValues)
-
-            if (onRequestClose) onRequestClose(e)
-          }}
-        >
+        <Button disabled={isSubmitDisabled} onClick={wrap}>
           Wrap
         </Button>
       </ButtonContainerStyled>

--- a/src/pages/PositionDetails/Contents.tsx
+++ b/src/pages/PositionDetails/Contents.tsx
@@ -381,6 +381,8 @@ export const Contents = (props: Props) => {
     [getEtherscanFormattedUrl]
   )
 
+  const isWorking = transfer.isLoading() || transfer.isFailure() || transfer.isSuccess()
+
   return (
     <CenteredCard
       dropdown={
@@ -600,7 +602,7 @@ export const Contents = (props: Props) => {
           onRequestClose={() => setOpenDisplayConditionsTableModal(false)}
         />
       )}
-      {(transfer.isLoading() || transfer.isFailure() || transfer.isSuccess()) && (
+      {isWorking && (
         <FullLoading
           actionButton={fullLoadingActionButton}
           icon={fullLoadingIcon}

--- a/src/pages/PositionDetails/Contents.tsx
+++ b/src/pages/PositionDetails/Contents.tsx
@@ -294,7 +294,7 @@ export const Contents = (props: Props) => {
       if (signer) {
         try {
           setTransfer(Remote.loading())
-          setTransactionTitle('Transfer Outcome Tokens')
+          setTransactionTitle('Transfer Tokens')
 
           const { address: addressTo, amount, positionId } = transferValue
           const addressFrom = await signer.getAddress()
@@ -606,7 +606,6 @@ export const Contents = (props: Props) => {
           icon={fullLoadingIcon}
           message={fullLoadingMessage}
           title={fullLoadingTitle}
-          width={transfer.isFailure() ? '400px' : '320px'}
         />
       )}
     </CenteredCard>

--- a/src/pages/PositionsList/index.tsx
+++ b/src/pages/PositionsList/index.tsx
@@ -353,7 +353,7 @@ export const PositionsList = () => {
     async (transferValue: TransferOptions) => {
       if (signer) {
         try {
-          setTransactionTitle('Transfer Outcome Tokens')
+          setTransactionTitle('Transfer Tokens')
           setTransfer(Remote.loading())
 
           const { address: addressTo, amount, positionId } = transferValue
@@ -525,7 +525,6 @@ export const PositionsList = () => {
           icon={fullLoadingIcon}
           message={fullLoadingMessage}
           title={fullLoadingTitle}
-          width={transfer.isFailure() ? '400px' : '320px'}
         />
       )}
     </>

--- a/src/pages/PositionsList/index.tsx
+++ b/src/pages/PositionsList/index.tsx
@@ -415,6 +415,7 @@ export const PositionsList = () => {
   }, [showFilters])
 
   const showSpinner = (isLoading || isSearching) && !error
+  const isWorking = transfer.isLoading() || transfer.isFailure() || transfer.isSuccess()
 
   return (
     <>
@@ -519,7 +520,7 @@ export const PositionsList = () => {
           positionId={selectedPositionId}
         />
       )}
-      {(transfer.isLoading() || transfer.isFailure() || transfer.isSuccess()) && (
+      {isWorking && (
         <FullLoading
           actionButton={fullLoadingActionButton}
           icon={fullLoadingIcon}


### PR DESCRIPTION
Closes #454

- Wrap Collateral - reject / Unwrap collateral - reject / Transfer outcome tokens - reject: All of the status info windows' widths should be correct now.
- Users can use the enter key in the wrap / unwrap modals to submit the form now. We could do the same for other forms later, if it makes sense.
- Fixed a nested button console error.