### PR TITLE
Use contract to calculate ids

### DIFF
--- a/src/services/conditionalTokens.ts
+++ b/src/services/conditionalTokens.ts
@@ -108,15 +108,11 @@ export class ConditionalTokensService {
     collateral: string
   ): Promise<PositionIdsArray[]> {
     const partitionsPromises = partition.map(async (indexSet: BigNumber) => {
-      const collectionId = ConditionalTokensService.getCollectionId(
-        parentCollection,
-        conditionId,
-        indexSet
-      )
+      const collectionId = await this.getCollectionId(parentCollection, conditionId, indexSet)
 
       const positionId = ConditionalTokensService.getPositionId(collateral, collectionId)
       logger.info(
-        `conditionId: ${conditionId} / parentCollection: ${parentCollection} / indexSet: ${indexSet.toString()}`
+        `conditionId: ${conditionId} / collectionId ${collectionId} / parentCollection: ${parentCollection} / indexSet: ${indexSet.toString()}`
       )
       logger.info(`Position: ${positionId}`)
 
@@ -179,6 +175,14 @@ export class ConditionalTokensService {
       indexSets
     )
     return this.provider.waitForTransaction(tx.hash, CONFIRMATIONS_TO_WAIT)
+  }
+
+  async getCollectionId(
+    parentCollectionId: string,
+    conditionId: string,
+    indexSet: BigNumber
+  ): Promise<string> {
+    return await this.contract.getCollectionId(parentCollectionId, conditionId, indexSet)
   }
 
   async mergePositions(


### PR DESCRIPTION
Closes #289 

This was more research than coding.
We were using a static method that uses some helpers provided by `id-helpers` to pre-calculate the resulting ids of making a split, this was working well for splitting from collateral but was failing if we split to deeper positions. For example, 

Condition: C
Collateral: $

If we made a split from $:C, we will get $:C1, $C2, $C4, and if we split again using the same condition, and position of indexSet 4, we will get $C4-1, $C4-2, and $C4-4, the id of the last case the id generated was different from the position actually created. This id didn't exist in the graph and neither has balance. Using `getCollectionId` from the contract and using that result to calculate the positionId solves the problem. 
Making another `getCollectionId` that doesn't use getCombinedCollectionId could work too. 


A somewhat related issue is #365, trying to solve this issue gives me some insight about the other. 
