### PR TITLE
(Fix) Remove Kleros from the oracles' filter, and make it the default arbitrator

### DIFF
--- a/src/components/filters/OraclesFilterDropdown/index.tsx
+++ b/src/components/filters/OraclesFilterDropdown/index.tsx
@@ -41,18 +41,18 @@ export const OraclesFilterDropdown = ({ onClick, value }: Props) => {
       },
       value: OracleFilterOptions.Custom,
     },
+    ...oracles
+      .filter((item) => item.name !== OracleFilterOptions.Kleros)
+      .map((item) => {
+        return {
+          text: item.description,
+          onClick: () => {
+            onClick(item.name as OracleFilterOptions, [item.address.toLowerCase()])
+          },
+          value: item.name as OracleFilterOptions,
+        }
+      }),
   ]
-
-  for (const oracle of oracles) {
-    const oracleItem = {
-      text: oracle.description,
-      onClick: () => {
-        onClick(oracle.name as OracleFilterOptions, [oracle.address.toLowerCase()])
-      },
-      value: oracle.name as OracleFilterOptions,
-    }
-    oraclesItems.push(oracleItem)
-  }
 
   return (
     <>

--- a/src/config/networkConfig.ts
+++ b/src/config/networkConfig.ts
@@ -102,30 +102,30 @@ const networks: { [K in NetworkIds]: Network } = {
     OMENGraphWsUri: OMEN_GRAPH_WS_MAINNET,
     oracles: [
       {
-        name: 'realitio',
-        description: 'Realit.io',
-        url: 'https://realit.io/',
-        address: '0x0e414d014a77971f4eaa22ab58e6d84d16ea838e',
-      },
-      {
         name: 'kleros',
         description: 'Kleros',
         url: 'https://kleros.io/',
         address: '0x0000000000000000000000000000000000000000',
       },
-    ],
-    arbitrators: [
       {
         name: 'realitio',
         description: 'Realit.io',
-        url: 'https://reality.eth.link',
-        address: '0xdc0a2185031ecf89f091a39c63c2857a7d5c301a',
+        url: 'https://realit.io/',
+        address: '0x0e414d014a77971f4eaa22ab58e6d84d16ea838e',
       },
+    ],
+    arbitrators: [
       {
         name: 'kleros',
         description: 'Kleros',
         url: 'https://kleros.io/',
         address: '0xd47f72a2d1d0E91b0Ec5e5f5d02B2dc26d00A14D',
+      },
+      {
+        name: 'realitio',
+        description: 'Realit.io',
+        url: 'https://reality.eth.link',
+        address: '0xdc0a2185031ecf89f091a39c63c2857a7d5c301a',
       },
     ],
     realitioTimeout: 86400,
@@ -175,30 +175,30 @@ const networks: { [K in NetworkIds]: Network } = {
     OMENGraphWsUri: OMEN_GRAPH_WS_RINKEBY,
     oracles: [
       {
-        name: 'realitio',
-        description: 'Realit.io',
-        url: 'https://realit.io/',
-        address: '0x576b76eebe6b5411c0ef310e65de9bff8a60130f',
-      },
-      {
         name: 'kleros',
         description: 'Kleros',
         url: 'https://kleros.io/',
         address: '0x0000000000000000000000000000000000000000',
       },
-    ],
-    arbitrators: [
       {
         name: 'realitio',
-        description: 'Realitio Team',
-        url: 'https://reality.eth.link',
-        address: '0x02321745bE4a141E78db6C39834396f8df00e2a0',
+        description: 'Realit.io',
+        url: 'https://realit.io/',
+        address: '0x576b76eebe6b5411c0ef310e65de9bff8a60130f',
       },
+    ],
+    arbitrators: [
       {
         name: 'kleros',
         description: 'Kleros',
         url: 'https://kleros.io/',
         address: '0xcafa054b1b054581faf65adce667bf1c684b6ef0',
+      },
+      {
+        name: 'realitio',
+        description: 'Realitio Team',
+        url: 'https://reality.eth.link',
+        address: '0x02321745bE4a141E78db6C39834396f8df00e2a0',
       },
     ],
     realitioTimeout: 10,
@@ -248,29 +248,29 @@ const networks: { [K in NetworkIds]: Network } = {
     OMENGraphWsUri: '',
     oracles: [
       {
+        name: 'kleros',
+        description: 'Kleros',
+        url: 'https://kleros.io/',
+        address: '0x0000000000000000000000000000000000000000',
+      },
+      {
         name: 'realitio',
         description: 'Realit.io',
         url: 'https://realit.io/',
         address: '0xDb56f2e9369E0D7bD191099125a3f6C370F8ed15',
       },
+    ],
+    arbitrators: [
       {
         name: 'kleros',
         description: 'Kleros',
         url: 'https://kleros.io/',
         address: '0x0000000000000000000000000000000000000000',
       },
-    ],
-    arbitrators: [
       {
         name: 'realitio',
         description: 'Realit.io',
         url: 'https://reality.eth.link',
-        address: '0x0000000000000000000000000000000000000000',
-      },
-      {
-        name: 'kleros',
-        description: 'Kleros',
-        url: 'https://kleros.io/',
         address: '0x0000000000000000000000000000000000000000',
       },
     ],

--- a/src/pages/PrepareCondition/index.tsx
+++ b/src/pages/PrepareCondition/index.tsx
@@ -590,8 +590,7 @@ export const PrepareCondition = () => {
                       {...(conditionType === ConditionType.omen && { readOnly: true })}
                     />
                     <SmallNote>
-                      <strong>Note:</strong> Realit.io is used the default oracle for Omen
-                      conditions.
+                      <strong>Note:</strong> Realit.io is the default oracle for Omen conditions.
                     </SmallNote>
                     {errorsOmenCondition.oracle && (
                       <ErrorContainer>

--- a/src/pages/PrepareCondition/index.tsx
+++ b/src/pages/PrepareCondition/index.tsx
@@ -15,6 +15,7 @@ import { ButtonContainer } from 'components/pureStyledComponents/ButtonContainer
 import { ErrorContainer, Error as ErrorMessage } from 'components/pureStyledComponents/Error'
 import { PageTitle } from 'components/pureStyledComponents/PageTitle'
 import { Row } from 'components/pureStyledComponents/Row'
+import { SmallNote } from 'components/pureStyledComponents/SmallNote'
 import { Textfield } from 'components/pureStyledComponents/Textfield'
 import { TitleControl } from 'components/pureStyledComponents/TitleControl'
 import { FullLoading } from 'components/statusInfo/FullLoading'
@@ -588,6 +589,10 @@ export const PrepareCondition = () => {
                       value={oracleOmenCondition}
                       {...(conditionType === ConditionType.omen && { readOnly: true })}
                     />
+                    <SmallNote>
+                      <strong>Note:</strong> Realit.io is used the default oracle for Omen
+                      conditions.
+                    </SmallNote>
                     {errorsOmenCondition.oracle && (
                       <ErrorContainer>
                         {errorsOmenCondition.oracle.type === 'required' && (

--- a/src/pages/PrepareCondition/index.tsx
+++ b/src/pages/PrepareCondition/index.tsx
@@ -92,11 +92,11 @@ export const PrepareCondition = () => {
   const oracle = networkConfig.getOracleFromName('realitio' as KnownOracle)
 
   const defaultValuesOmen = {
+    arbitrator: networkConfig.getArbitratorFromName('kleros'),
+    category: Categories.businessAndFinance,
+    oracle: oracle.address,
     questionTitle: '',
     resolutionDate: null,
-    category: Categories.businessAndFinance,
-    arbitrator: networkConfig.getArbitratorFromName('realitio'),
-    oracle: oracle.address,
   }
 
   const {


### PR DESCRIPTION
Closes #474 
Closes #475

Also changed the order of the arbitrator's items to make Kleros appear first (besides it being the default option), and added a little note to explain what the oracle's address is for Omen conditions.