### PR TITLE
(fix) Overlapping text

### DIFF
--- a/src/pages/ConditionsList/index.tsx
+++ b/src/pages/ConditionsList/index.tsx
@@ -208,7 +208,7 @@ export const ConditionsList: React.FC = () => {
         cell: (row: Conditions_conditions) => (
           <Hash onClick={() => handleRowClick(row)} value={row.oracle} />
         ),
-        name: 'Reporting Address / Oracle',
+        name: 'Reporter / Oracle',
         selector: 'oracle',
         sortable: true,
       },

--- a/src/theme/tableCustomStyles.tsx
+++ b/src/theme/tableCustomStyles.tsx
@@ -2,7 +2,7 @@ import { IDataTableStyles } from 'react-data-table-component'
 
 import theme from 'theme/index'
 
-const horizontalPadding = '15px'
+const horizontalPadding = '25px'
 
 export const customStyles: IDataTableStyles = {
   table: {


### PR DESCRIPTION
Closes #459 

- Changed "Reporting Address / Oracle" for "Reporter / Oracle"
- Added a bit of more padding to the data cells to better separate the contents.

There's not much else that can be done (and it's worth the time), I think.