### PR TITLE
(fix) Link icon width

### DIFF
--- a/src/components/form/DisplayTablePositions/index.tsx
+++ b/src/components/form/DisplayTablePositions/index.tsx
@@ -70,7 +70,6 @@ export const DisplayTablePositions = (props: Props) => {
         cell: (row: PositionWithUserBalanceWithDecimals) => {
           return <Hash externalLink href={`/positions/${row.id}`} value={row.id} />
         },
-        maxWidth: '250px',
         minWidth: '250px',
         name: 'Position Id',
         selector: (row: PositionWithUserBalanceWithDecimals) => row.id,
@@ -88,8 +87,8 @@ export const DisplayTablePositions = (props: Props) => {
             />
           )
         },
-        maxWidth: '150px',
-        minWidth: '150px',
+        maxWidth: '120px',
+        minWidth: '120px',
         name: 'Collateral',
         selector: 'collateralToken',
         sortable: true,


### PR DESCRIPTION
Closes #482 

I couldn't get to reproduce the issue, but I suspect it has something to do with the screen's width and / or the first column's width (which wash fixed and isn't anymore).

It should be fixed now, but I can't be 100% sure.