### PR TITLE
Add a possibility to search by a custom collateral symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@react-hook/debounce": "^3.0.0",
     "@realitio/realitio-lib": "^2.0.2",
     "@types/contract-proxy-kit": "^1.0.1",
+    "@uniswap/default-token-list": "^1.5.0",
     "@walletconnect/web3-provider": "^1.3.1",
     "apollo": "^2.28.3",
     "apollo-cache-inmemory": "^1.6.6",

--- a/src/config/networkConfig.ts
+++ b/src/config/networkConfig.ts
@@ -350,11 +350,11 @@ export class NetworkConfig {
   getTokenFromAddress(address: string): Maybe<Token> {
     const tokens = networks[this.networkId].tokens
 
-    const tokenDefault = tokens.find((token: Token) =>
+    const tokenFromDefaultList = tokens.find((token: Token) =>
       token.address.toLowerCase().includes(address.toLowerCase())
     )
-    if (tokenDefault) {
-      return tokenDefault
+    if (tokenFromDefaultList) {
+      return tokenFromDefaultList
     }
 
     const tokenFromUniswap = this.getTokensFromUniswap().find(

--- a/src/config/networkConfig.ts
+++ b/src/config/networkConfig.ts
@@ -447,11 +447,11 @@ export class NetworkConfig {
   getTokenFromName(tokenName: string): Maybe<Token> {
     const tokens = networks[this.networkId].tokens
 
-    const tokenDefault = tokens.find((token: Token) =>
+    const tokenFromDefaultList = tokens.find((token: Token) =>
       token.symbol.toLowerCase().includes(tokenName.toLowerCase())
     )
-    if (tokenDefault) {
-      return tokenDefault
+    if (tokenFromDefaultList) {
+      return tokenFromDefaultList
     }
 
     const tokenFromUniswap = this.getTokensFromUniswap().find(

--- a/src/config/networkConfig.ts
+++ b/src/config/networkConfig.ts
@@ -1,3 +1,4 @@
+import UniswapTokens from '@uniswap/default-token-list'
 import {
   CONDITIONAL_TOKEN_CONTRACT_ADDRESS_FOR_GANACHE,
   CONDITIONAL_TOKEN_CONTRACT_ADDRESS_FOR_MAINNET,
@@ -322,6 +323,10 @@ export class NetworkConfig {
     return networks[this.networkId].tokens
   }
 
+  getTokensFromUniswap() {
+    return UniswapTokens.tokens
+  }
+
   getOracles(): Oracle[] {
     return networks[this.networkId].oracles
   }
@@ -342,17 +347,31 @@ export class NetworkConfig {
     return networks[this.networkId].earliestBlockToCheck
   }
 
-  getTokenFromAddress(address: string): Token {
+  getTokenFromAddress(address: string): Maybe<Token> {
     const tokens = networks[this.networkId].tokens
 
-    for (const token of tokens) {
-      const tokenAddress = token.address
-      if (tokenAddress.toLowerCase() === address.toLowerCase()) {
-        return token
+    const tokenDefault = tokens.find((token: Token) =>
+      token.address.toLowerCase().includes(address.toLowerCase())
+    )
+    if (tokenDefault) {
+      return tokenDefault
+    }
+
+    const tokenFromUniswap = this.getTokensFromUniswap().find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (token: any) =>
+        token.address.toLowerCase().includes(address.toLowerCase()) &&
+        token.chainId === this.networkId
+    )
+    if (tokenFromUniswap) {
+      return {
+        symbol: tokenFromUniswap.symbol,
+        address: tokenFromUniswap.address,
+        decimals: tokenFromUniswap.decimals,
       }
     }
 
-    throw new Error(`Couldn't find token with address '${address}' in network '${this.networkId}'`)
+    return null
   }
 
   getOracleFromAddress(address: string): Oracle {
@@ -425,10 +444,31 @@ export class NetworkConfig {
     }
   }
 
-  getTokenFromName(tokenName: string): Token | undefined {
+  getTokenFromName(tokenName: string): Maybe<Token> {
     const tokens = networks[this.networkId].tokens
 
-    return tokens.find((token: Token) => token.symbol.toLowerCase() === tokenName.toLowerCase())
+    const tokenDefault = tokens.find((token: Token) =>
+      token.symbol.toLowerCase().includes(tokenName.toLowerCase())
+    )
+    if (tokenDefault) {
+      return tokenDefault
+    }
+
+    const tokenFromUniswap = this.getTokensFromUniswap().find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (token: any) =>
+        token.symbol.toLowerCase().includes(tokenName.toLowerCase()) &&
+        token.chainId === this.networkId
+    )
+    if (tokenFromUniswap) {
+      return {
+        symbol: tokenFromUniswap.symbol,
+        address: tokenFromUniswap.address,
+        decimals: tokenFromUniswap.decimals,
+      }
+    }
+
+    return null
   }
 
   getRealitioTimeout(): number {

--- a/src/util/tools.ts
+++ b/src/util/tools.ts
@@ -338,20 +338,22 @@ export const getTokenSummary = async (
   provider: Provider,
   collateralToken: string
 ): Promise<Token> => {
-  try {
-    const { decimals, symbol } = networkConfig.getTokenFromAddress(collateralToken)
+  const token = networkConfig.getTokenFromAddress(collateralToken)
+
+  if (token) {
+    const { address, decimals, symbol } = token
     return {
-      address: collateralToken,
+      address,
       decimals,
       symbol,
     }
-  } catch (e) {
+  } else {
     try {
       const erc20Service = new ERC20Service(provider, collateralToken)
-      const { decimals, symbol } = await erc20Service.getProfileSummary()
+      const { address, decimals, symbol } = await erc20Service.getProfileSummary()
 
       return {
-        address: collateralToken,
+        address,
         decimals,
         symbol,
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2510,6 +2510,11 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@uniswap/default-token-list@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/default-token-list/-/default-token-list-1.5.0.tgz#daa07575e2ae6bf92441e64af32122e3847ffcb7"
+  integrity sha512-TF5U+9ED6N+qrJKfoocci2vJ0u/57cxeUrnoDazqzLnGcoAp9FVMyi+n0ebz6Ka1AqFCIXkHGwQy+8GVQFTQdw==
+
 "@walletconnect/client@^1.3.1":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/client/-/client-1.3.1.tgz#5b8160fe15615ca7017a6be1b125d885e39ddf12"


### PR DESCRIPTION
Closes #504 

@elena-zh I added the uniswap package, you can check it here https://gateway.ipfs.io/ipns/tokens.uniswap.org
We can't search a token by symbol, unless we have an array file with all the token information. For rinkeby, is really difficult to have a curated list of token, so the file is really small with only a couple of tokens. So, just to consider, I added this uniswap package, that includes a file with a list of curated tokens for mainnet (remember to test this in mainnet).

The search by symbol, only check for the first ocurrence of a match, not multiple checks, for example:
- Search the ren symbol
- There are no positions with the collateral ren
- But exist some positions If we search by renBTC symbol
- Maybe a good feature is to search all the words that starts with ren, but is very complicated (create an issue for this)