### PR TITLE
Setup production GA env var on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get -y install python-pip python-dev
   - pip install awscli --upgrade --user
+before_script:
+  - if [[ -n "$TRAVIS_TAG" ]]; then export REACT_APP_GOOGLE_ANALYTICS_ID=${REACT_APP_GOOGLE_ANALYTICS_ID_PROD}; fi;
 script:
   - yarn test --coverage
   - yarn build

--- a/travis/deploy_release.sh
+++ b/travis/deploy_release.sh
@@ -17,7 +17,7 @@ then
 
   REVIEW_RELEASE_FOLDER="$REPO_NAME_ALPHANUMERIC/$TRAVIS_TAG_ALPHANUMERIC"
 
-  # Deploy safe-team release project
+  # Deploy cte release project
   aws s3 sync build s3://${REVIEW_BUCKET_NAME}/${REVIEW_RELEASE_FOLDER} --delete --exclude "*.html" --exclude "/page-data" --metadata-directive REPLACE --cache-control max-age=31536000,public
 
   aws s3 sync build s3://${REVIEW_BUCKET_NAME}/${REVIEW_RELEASE_FOLDER} --delete --exclude "*" --include "*.html" --metadata-directive REPLACE --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html


### PR DESCRIPTION
Setup production environment variable `REACT_APP_GOOGLE_ANALYTICS_ID` for production deployments.

This feature will separate the GA env vars from different environments.