### PR TITLE
(Fix) Overlapping lines

### DIFF
--- a/src/components/mergePositions/MergePreview/index.tsx
+++ b/src/components/mergePositions/MergePreview/index.tsx
@@ -1,5 +1,6 @@
 import { BigNumber } from 'ethers/utils'
 import React, { useEffect, useMemo, useState } from 'react'
+import styled from 'styled-components'
 
 import {
   StripedList,
@@ -12,6 +13,10 @@ import { useMultiPositionsContext } from 'contexts/MultiPositionsContext'
 import { useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
 import { getLogger } from 'util/logger'
 import { arePositionMergeablesByCondition, getMergePreview, getTokenSummary } from 'util/tools'
+
+const StripedListItemBreakable = styled.div`
+  word-break: break-all;
+`
 
 interface Props {
   amount: BigNumber
@@ -54,11 +59,11 @@ export const MergePreview = ({ amount }: Props) => {
     <TitleValue
       title="Merged Positions Preview"
       value={
-        <StripedList maxHeight="41px">
+        <StripedList maxHeight="none" minHeight="41px">
           {mergedPosition ? (
-            <StripedListItem>
+            <StripedListItemBreakable>
               <strong>{mergedPosition}</strong>
-            </StripedListItem>
+            </StripedListItemBreakable>
           ) : (
             <StripedListEmpty>No merged positions yet.</StripedListEmpty>
           )}

--- a/src/components/mergePositions/MergePreview/index.tsx
+++ b/src/components/mergePositions/MergePreview/index.tsx
@@ -14,7 +14,7 @@ import { useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
 import { getLogger } from 'util/logger'
 import { arePositionMergeablesByCondition, getMergePreview, getTokenSummary } from 'util/tools'
 
-const StripedListItemBreakable = styled.div`
+const StripedListItemBreakable = styled(StripedListItem)`
   word-break: break-all;
 `
 

--- a/src/components/mergePositions/MergePreview/index.tsx
+++ b/src/components/mergePositions/MergePreview/index.tsx
@@ -1,11 +1,10 @@
 import { BigNumber } from 'ethers/utils'
 import React, { useEffect, useMemo, useState } from 'react'
-import styled from 'styled-components'
 
 import {
   StripedList,
   StripedListEmpty,
-  StripedListItem,
+  StripedListItemPreview,
 } from 'components/pureStyledComponents/StripedList'
 import { TitleValue } from 'components/text/TitleValue'
 import { useConditionContext } from 'contexts/ConditionContext'
@@ -13,10 +12,6 @@ import { useMultiPositionsContext } from 'contexts/MultiPositionsContext'
 import { useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
 import { getLogger } from 'util/logger'
 import { arePositionMergeablesByCondition, getMergePreview, getTokenSummary } from 'util/tools'
-
-const StripedListItemBreakable = styled(StripedListItem)`
-  word-break: break-all;
-`
 
 interface Props {
   amount: BigNumber
@@ -61,9 +56,7 @@ export const MergePreview = ({ amount }: Props) => {
       value={
         <StripedList maxHeight="none" minHeight="41px">
           {mergedPosition ? (
-            <StripedListItemBreakable>
-              <strong>{mergedPosition}</strong>
-            </StripedListItemBreakable>
+            <StripedListItemPreview>{mergedPosition}</StripedListItemPreview>
           ) : (
             <StripedListEmpty>No merged positions yet.</StripedListEmpty>
           )}

--- a/src/components/pureStyledComponents/StripedList.tsx
+++ b/src/components/pureStyledComponents/StripedList.tsx
@@ -28,6 +28,7 @@ export const StripedListItem = styled.div<{ justifyContent?: string }>`
   line-height: 1.3;
   padding: 12px 20px;
   text-align: left;
+  word-break: break-all;
 
   &:nth-child(even) {
     background-color: ${(props) => props.theme.colors.whitesmoke2};
@@ -48,6 +49,10 @@ export const StripedListItemLessPadding = styled(StripedListItem)`
   padding: 8px 12px;
 `
 
+export const StripedListItemPreview = styled(StripedListItem)`
+  font-weight: 600;
+`
+
 StripedListItem.defaultProps = {
   justifyContent: 'space-between',
 }
@@ -58,6 +63,7 @@ export const StripedListEmpty = styled.div`
   display: flex;
   flex-grow: 1;
   font-size: 15px;
+  font-weight: 600;
   height: 100%;
   justify-content: center;
   line-height: 1.5;

--- a/src/components/pureStyledComponents/StripedList.tsx
+++ b/src/components/pureStyledComponents/StripedList.tsx
@@ -25,7 +25,7 @@ export const StripedListItem = styled.div<{ justifyContent?: string }>`
   font-size: 15px;
   font-weight: 400;
   justify-content: ${(props) => props.justifyContent};
-  line-height: 1;
+  line-height: 1.3;
   padding: 12px 20px;
   text-align: left;
 

--- a/src/components/splitPosition/PositionPreview/index.tsx
+++ b/src/components/splitPosition/PositionPreview/index.tsx
@@ -13,6 +13,14 @@ import { GetPosition_position } from 'types/generatedGQLForCTE'
 import { positionString } from 'util/tools'
 import { SplitFromType, Token } from 'util/types'
 
+const StripedListStyled = styled(StripedList)`
+  margin-top: 6px;
+`
+
+const StripedListItemBreakable = styled(StripedListItem)`
+  word-break: break-all;
+`
+
 interface Props {
   amount: BigNumber
   conditionId: string
@@ -21,10 +29,6 @@ interface Props {
   selectedCollateral: Token
   splitFrom: SplitFromType
 }
-
-const StripedListStyled = styled(StripedList)`
-  margin-top: 6px;
-`
 
 export const PositionPreview = ({
   amount,
@@ -80,7 +84,7 @@ export const PositionPreview = ({
         <StripedListStyled>
           {splitPositionPreview.length > 0 ? (
             splitPositionPreview.map((preview, i) => (
-              <StripedListItem key={`preview-${i}`}>{preview}</StripedListItem>
+              <StripedListItemBreakable key={`preview-${i}`}>{preview}</StripedListItemBreakable>
             ))
           ) : (
             <StripedListEmpty>No Split Positions.</StripedListEmpty>

--- a/src/components/splitPosition/PositionPreview/index.tsx
+++ b/src/components/splitPosition/PositionPreview/index.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import {
   StripedList,
   StripedListEmpty,
-  StripedListItem,
+  StripedListItemPreview,
 } from 'components/pureStyledComponents/StripedList'
 import { TitleValue } from 'components/text/TitleValue'
 import { useCollateral } from 'hooks/useCollateral'
@@ -15,10 +15,6 @@ import { SplitFromType, Token } from 'util/types'
 
 const StripedListStyled = styled(StripedList)`
   margin-top: 6px;
-`
-
-const StripedListItemBreakable = styled(StripedListItem)`
-  word-break: break-all;
 `
 
 interface Props {
@@ -84,7 +80,7 @@ export const PositionPreview = ({
         <StripedListStyled>
           {splitPositionPreview.length > 0 ? (
             splitPositionPreview.map((preview, i) => (
-              <StripedListItemBreakable key={`preview-${i}`}>{preview}</StripedListItemBreakable>
+              <StripedListItemPreview key={`preview-${i}`}>{preview}</StripedListItemPreview>
             ))
           ) : (
             <StripedListEmpty>No Split Positions.</StripedListEmpty>

--- a/src/pages/PositionDetails/Contents.tsx
+++ b/src/pages/PositionDetails/Contents.tsx
@@ -115,6 +115,10 @@ const Link = styled.a`
   ${LinkCSS}
 `
 
+const StripedListItemBreakable = styled(StripedListItem)`
+  word-break: break-all;
+`
+
 const TooltipStyled = styled(Tooltip)`
   cursor: pointer;
   margin: 0 0 0 8px;
@@ -640,7 +644,7 @@ export const Contents = (props: Props) => {
       <Row cols="1fr" marginBottomXL>
         <TitleValue
           title="Position Preview"
-          value={<StripedListItem>{positionPreview || ''} </StripedListItem>}
+          value={<StripedListItemBreakable>{positionPreview || ''} </StripedListItemBreakable>}
         />
       </Row>
       {isWrapModalOpen && (

--- a/src/pages/PositionDetails/Contents.tsx
+++ b/src/pages/PositionDetails/Contents.tsx
@@ -34,6 +34,7 @@ import {
   StripedListEmpty,
   StripedListItem,
   StripedListItemLessPadding,
+  StripedListItemPreview,
 } from 'components/pureStyledComponents/StripedList'
 import { FullLoading } from 'components/statusInfo/FullLoading'
 import { IconTypes } from 'components/statusInfo/common'
@@ -113,10 +114,6 @@ const InternalLink = styled(NavLink)`
 
 const Link = styled.a`
   ${LinkCSS}
-`
-
-const StripedListItemBreakable = styled(StripedListItem)`
-  word-break: break-all;
 `
 
 const TooltipStyled = styled(Tooltip)`
@@ -641,12 +638,14 @@ export const Contents = (props: Props) => {
           }
         />
       </Row>
-      <Row cols="1fr" marginBottomXL>
-        <TitleValue
-          title="Position Preview"
-          value={<StripedListItemBreakable>{positionPreview || ''} </StripedListItemBreakable>}
-        />
-      </Row>
+      {positionPreview && (
+        <Row cols="1fr" marginBottomXL>
+          <TitleValue
+            title="Position Preview"
+            value={<StripedListItemPreview>{positionPreview}</StripedListItemPreview>}
+          />
+        </Row>
+      )}
       {isWrapModalOpen && (
         <WrapModal
           balance={balanceERC1155}


### PR DESCRIPTION
Closes #565

It should look something like these:

![Screen Shot 2020-11-05 at 15 59 49](https://user-images.githubusercontent.com/4015436/98285454-54454480-1f81-11eb-83d7-bd77bf42b0de.png)
![Screen Shot 2020-11-05 at 16 07 58](https://user-images.githubusercontent.com/4015436/98285460-56a79e80-1f81-11eb-94ec-deeff45e5ea7.png)
![Screen Shot 2020-11-05 at 16 04 36](https://user-images.githubusercontent.com/4015436/98285465-57d8cb80-1f81-11eb-9e44-28a623bc05ef.png)
