### PR TITLE
(Fix) Sort icon

### DIFF
--- a/src/theme/dataTableCSS.tsx
+++ b/src/theme/dataTableCSS.tsx
@@ -47,6 +47,12 @@ export const dataTableCSS = css`
       div {
         white-space: nowrap;
       }
+
+      .rdt_TableCol_Sortable {
+        > span {
+          padding: 0 8px;
+        }
+      }
     }
 
     .rdt_TableRow {


### PR DESCRIPTION
Closes #281

There's no (easy / official) way to change the sort icon's order. Check [here](https://github.com/jbetancur/react-data-table-component/issues/139#issuecomment-510662948) for some extra info _("Notice that right align columns have the icon left render and all other alignments have it on the right.")_

The same goes for always showing the icons (add to it that all the icons always point towards the same direction, regardless of what column is the sorting applied to).

So... I just added some padding to separate the icon a bit from the text. The rest is not worth the effort / time IMO.

![Screen Shot 2020-11-05 at 16 26 49](https://user-images.githubusercontent.com/4015436/98287736-8d32e880-1f84-11eb-80f2-31d113bb80c4.png)
