### PR TITLE
(fix) remove number input spinners on firefox

### DIFF
--- a/src/components/filters/MinMaxFilter/index.tsx
+++ b/src/components/filters/MinMaxFilter/index.tsx
@@ -7,13 +7,14 @@ import { FilterTitle } from 'components/pureStyledComponents/FilterTitle'
 import { Textfield } from 'components/pureStyledComponents/Textfield'
 import { MAX_OUTCOMES_ALLOWED, MIN_OUTCOMES_ALLOWED } from 'config/constants'
 
-const Wrapper = styled.div``
+const Wrapper = styled.div`
+  /* margin-bottom: 8px; */
+`
 
 const Row = styled.div`
   column-gap: 8px;
   display: grid;
   grid-template-columns: 1fr 32px;
-  margin-bottom: 8px;
 
   &:last-child {
     margin-bottom: 0;
@@ -34,6 +35,7 @@ const Dash = styled.div`
 `
 
 const TextFieldStyled = styled(Textfield)`
+  -moz-appearance: textfield;
   font-size: 14px;
   height: 32px;
   min-width: 0;
@@ -126,6 +128,7 @@ export const MinMaxFilter: React.FC<Props> = (props) => {
         <FieldsWrapper>
           <TextFieldStyled
             autoComplete="off"
+            max={MAX_OUTCOMES_ALLOWED}
             min={MIN_OUTCOMES_ALLOWED}
             name="min"
             onChange={onChangeMinInternal}
@@ -138,6 +141,7 @@ export const MinMaxFilter: React.FC<Props> = (props) => {
           <TextFieldStyled
             autoComplete="off"
             max={MAX_OUTCOMES_ALLOWED}
+            min={MIN_OUTCOMES_ALLOWED}
             name="max"
             onChange={onChangeMaxInternal}
             onKeyPress={onKeyPress}


### PR DESCRIPTION
Closes #607

It should look like this now on Firefox.

![Screen Shot 2020-11-12 at 17 07 36](https://user-images.githubusercontent.com/4015436/98990852-caa9ef80-2509-11eb-91c8-5e7fed1beb01.png)
