### PR TITLE
Make impossible to merge positions using using conditions of shallower positions 

### DIFF
--- a/src/util/tools.ts
+++ b/src/util/tools.ts
@@ -7,6 +7,7 @@ import { BYTES_REGEX } from 'config/constants'
 import { NetworkConfig } from 'config/networkConfig'
 import { PositionWithUserBalanceWithDecimals } from 'hooks/usePositionsList'
 import { ConditionInformation } from 'hooks/utils'
+import isEqual from 'lodash.isequal'
 import zipObject from 'lodash.zipobject'
 import { ERC20Service } from 'services/erc20'
 import { GetCondition_condition } from 'types/generatedGQLForCTE'
@@ -193,8 +194,7 @@ export const getRedeemedPreview = (
 
 export const positionsSameConditionsSet = (positions: PositionWithUserBalanceWithDecimals[]) => {
   // all postions include same conditions set and collateral token
-  const conditionIdsSet = positions.map((position) => [...position.conditionIds].sort().join(''))
-  return conditionIdsSet.every((set) => set === conditionIdsSet[0])
+  return positions.every((position) => isEqual(position.conditionIds, positions[0].conditionIds))
 }
 
 // more than 1 position


### PR DESCRIPTION
Closes #611 

I was able to merge without any changes for the base case (positions c2c1p1 - c2c1p4 merged by c2), I just filtered conditions to avoid showing conditions shared in shallower positions.

For the record, the problem was that if you have a condition C1, and split it like this
``` 
$:C1:O1 (C1-P1)
$:C1:O2 (C1-P2)
```

The indexSet of C1-P1 will be `[1]` and for C1-P2 will be `[2]`, in both cases the conditionsIds will be [C1]

If we split again, using C1-P2, with C2 for example of 4 outcomes, we will get
```
C1-P2:C2:O1 [2 1] [C1 C2]
C1-P2:C2:O2 [2 2] [C1 C2]
C1-P2:C2:O3 [2 4] [C1 C2]
C1-P2:C2:O4 [2 8] [C1 C2]
```

And then we try to merge any number >= 2 of positions from that set using C1, we will get a partition with the form of [2 2] or [2 2 2], etc. This is a disjoint partition. With the extra filter, in the dropdown, we only show C2.

Also, this should improve the situation of #612, the problem is that for the graph conditionsIds is an array and the indexSets is a set, so if we in the previous example use again C1, what we would obtain is something like

```
C1-P2:C1:O1 [2 1] [C1 C1]
C1-P2:C1:O2 [2] [C1 C1]
```

Because we can't have in an indexSet field a `[2 2]`. 

For a real case, in rinkeby.

```
  p1: position(id: "0x70996f31153f38815a33a62550672c4694d67c202afbb776733f805bf0010afc") {
    indexSets
    conditionIds
  }
  p2: position(id: "0x201bbf0ee7f77ed43e31b94f8172ceede684a409144a68206b6ad5f0426bcdb1") {
    indexSets
    conditionIds
  }
  p3: position(id: "0xa2887462a95f9499cff7c5e099344805780880b0d8f1cf47c958eced7640e55d") {
    indexSets
    conditionIds
  }
}
```

p1 and p2 can't be merged with anything, and p3 is compatible with shallower positions (and can be merged successfully), I think we must avoid positions that are recursive, or with cycles. Or find a solution in the graph side, with the data received there no much more that can be done to avoid this.