### PR TITLE
(Fix) Set active rows styling

### DIFF
--- a/src/components/table/SelectableConditionTable/index.tsx
+++ b/src/components/table/SelectableConditionTable/index.tsx
@@ -1,7 +1,7 @@
 import { useDebounceCallback } from '@react-hook/debounce'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import DataTable from 'react-data-table-component'
-import styled from 'styled-components'
+import styled, { withTheme } from 'styled-components'
 
 import { ButtonCopy } from 'components/buttons/ButtonCopy'
 import { ConditionTypeFilterDropdown } from 'components/filters/ConditionTypeFilterDropdown'
@@ -53,15 +53,17 @@ const TableControlsStyled = styled(TableControls)`
 `
 
 interface Props {
-  onRowClicked: (row: Conditions_conditions) => void
-  selectedConditionId?: string | undefined
-  onClearSelection: () => void
-  title?: string
   allowToDisplayOnlyConditionsToReport?: boolean
+  onClearSelection: () => void
+  onRowClicked: (row: Conditions_conditions) => void
   refetch?: boolean
+  selectedConditionId?: string | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  theme?: any
+  title?: string
 }
 
-export const SelectableConditionTable: React.FC<Props> = (props) => {
+const SelectConditionTable: React.FC<Props> = (props) => {
   const { _type: status, CPKService, address, networkConfig } = useWeb3ConnectedOrInfura()
 
   const { getValue } = useLocalStorage(LocalStorageManagement.ConditionId)
@@ -72,6 +74,7 @@ export const SelectableConditionTable: React.FC<Props> = (props) => {
     onRowClicked,
     refetch,
     selectedConditionId,
+    theme,
     title = 'Conditions',
     ...restProps
   } = props
@@ -371,6 +374,20 @@ export const SelectableConditionTable: React.FC<Props> = (props) => {
     selectedFromCreationDate,
   ])
 
+  const conditionalRowStyles = [
+    {
+      when: (condition: Conditions_conditions) => selectedConditionId === condition.id,
+      style: {
+        backgroundColor: theme.colors.whitesmoke3,
+        color: theme.colors.darkerGrey,
+        '&:hover': {
+          cursor: 'default',
+        },
+        pointerEvents: 'none' as const,
+      },
+    },
+  ]
+
   return (
     <TitleValue
       title={title}
@@ -454,6 +471,7 @@ export const SelectableConditionTable: React.FC<Props> = (props) => {
           <DataTable
             className="outerTableWrapper condensedTable"
             columns={columns}
+            conditionalRowStyles={conditionalRowStyles}
             customStyles={customStyles}
             data={showSpinner ? [] : conditionList.length ? conditionList : []}
             highlightOnHover
@@ -482,3 +500,5 @@ export const SelectableConditionTable: React.FC<Props> = (props) => {
     />
   )
 }
+
+export const SelectableConditionTable = withTheme(SelectConditionTable)

--- a/src/components/table/SelectablePositionTable/index.tsx
+++ b/src/components/table/SelectablePositionTable/index.tsx
@@ -1,7 +1,7 @@
 import { useDebounceCallback } from '@react-hook/debounce'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import DataTable from 'react-data-table-component'
-import styled from 'styled-components'
+import styled, { withTheme } from 'styled-components'
 
 import { TokenIcon } from 'components/common/TokenIcon'
 import { CollateralFilterDropdown } from 'components/filters/CollateralFilterDropdown'
@@ -50,19 +50,21 @@ const TitleValueExtended = styled(TitleValue)<{ hideTitle?: boolean }>`
 `
 
 interface Props {
+  clearFilters?: boolean
   hideTitle?: boolean
-  onRowClicked: (position: PositionWithUserBalanceWithDecimals) => void
   onClearCallback?: () => void
   onFilterCallback?: (
     positions: PositionWithUserBalanceWithDecimals[]
   ) => PositionWithUserBalanceWithDecimals[]
-  selectedPosition: Maybe<PositionWithUserBalanceWithDecimals>
-  title?: string
-  clearFilters?: boolean
+  onRowClicked: (position: PositionWithUserBalanceWithDecimals) => void
   refetch?: boolean
+  selectedPosition: Maybe<PositionWithUserBalanceWithDecimals>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  theme?: any
+  title?: string
 }
 
-export const SelectablePositionTable: React.FC<Props> = (props) => {
+const SelectPositionTable: React.FC<Props> = (props) => {
   const {
     clearFilters,
     hideTitle,
@@ -71,6 +73,7 @@ export const SelectablePositionTable: React.FC<Props> = (props) => {
     onRowClicked,
     refetch,
     selectedPosition,
+    theme,
     title = 'Positions',
     ...restProps
   } = props
@@ -303,6 +306,21 @@ export const SelectablePositionTable: React.FC<Props> = (props) => {
     selectedFromCreationDate,
   ])
 
+  const conditionalRowStyles = [
+    {
+      when: (position: PositionWithUserBalanceWithDecimals) =>
+        !!(selectedPosition && selectedPosition?.id === position.id),
+      style: {
+        backgroundColor: theme.colors.whitesmoke3,
+        color: theme.colors.darkerGrey,
+        '&:hover': {
+          cursor: 'default',
+        },
+        pointerEvents: 'none' as const,
+      },
+    },
+  ]
+
   return (
     <TitleValueExtended
       hideTitle={hideTitle}
@@ -363,6 +381,7 @@ export const SelectablePositionTable: React.FC<Props> = (props) => {
           <DataTable
             className="outerTableWrapper condensedTable"
             columns={defaultColumns}
+            conditionalRowStyles={conditionalRowStyles}
             customStyles={customStyles}
             data={showSpinner ? [] : positionList.length ? positionList : []}
             highlightOnHover
@@ -390,3 +409,5 @@ export const SelectablePositionTable: React.FC<Props> = (props) => {
     />
   )
 }
+
+export const SelectablePositionTable = withTheme(SelectPositionTable)

--- a/src/theme/dataTableCSS.tsx
+++ b/src/theme/dataTableCSS.tsx
@@ -64,6 +64,7 @@ export const dataTableCSS = css`
       border-bottom-color: ${(props) => props.theme.colors.lightGrey}!important;
 
       &:hover {
+        background-color: ${(props) => props.theme.colors.whitesmoke3}!important;
         color: ${(props) => props.theme.colors.darkerGrey}!important;
       }
 


### PR DESCRIPTION
Closes #649

> Selected position/condition is not highlighted in the select position/condition sections

It's highlighted now.

> Also, the selection is not in bold (as it was discussed [here](https://altoros.slack.com/archives/C0147SJMANS/p1603120875007300))

I remember the chat, but I checked and designs' fonts are not bold. There's a reason for that, though: changing font weight on hover / state change tends to displace elements. That's why I usually don't do it. Font color is changed to a darker one, though.

> In addition, not selected position in the Merge with section should be in the same color.

I don't understand this.

> Selected - highlighted and in bold

Checkbox indicates selection, rows and fonts styling stay the same.