### PR TITLE
(Fix) Table height

### DIFF
--- a/src/components/form/DisplayTablePositions/index.tsx
+++ b/src/components/form/DisplayTablePositions/index.tsx
@@ -18,7 +18,7 @@ interface PropsWrapper extends SplitStatus {
   callbackOnHistoryPush?: () => void
 }
 
-export const DisplayTablePositionsWrapper = (props: PropsWrapper) => {
+export const DisplayTablePositionsWrapper: React.FC<PropsWrapper> = (props) => {
   const { callbackOnHistoryPush, collateral, positionIds } = props
   const { collateral: collateralFetched, loading } = useCollateral(collateral)
 
@@ -42,7 +42,7 @@ export const DisplayTablePositionsWrapper = (props: PropsWrapper) => {
     <DisplayTablePositions
       callbackOnHistoryPush={callbackOnHistoryPush}
       positions={positions as PositionWithUserBalanceWithDecimals[]}
-    ></DisplayTablePositions>
+    />
   ) : null
 }
 
@@ -52,7 +52,7 @@ interface Props {
   positions: PositionWithUserBalanceWithDecimals[]
 }
 
-export const DisplayTablePositions = (props: Props) => {
+export const DisplayTablePositions: React.FC<Props> = (props) => {
   const { callbackOnHistoryPush, isLoading, positions } = props
   const history = useHistory()
 
@@ -122,13 +122,14 @@ export const DisplayTablePositions = (props: Props) => {
         isLoading ? (
           <InlineLoading size={SpinnerSize.small} />
         ) : (
-          <EmptyContentText>No positions found.</EmptyContentText>
+          <EmptyContentText>No positions.</EmptyContentText>
         )
       }
       noHeader
       pagination
       paginationPerPage={5}
       paginationRowsPerPageOptions={[5, 10, 15]}
+      style={{ minHeight: isLoading || !positions.length ? '41px' : '280px' }}
     />
   )
 }


### PR DESCRIPTION
Closes #674

I'm not entirely convinced with this fix, but whatever... Tables in the app have a fixed min height, and this is a table so it should stay the same height even if there is no content. But in this case is at the end of the details, and there's nothing after if so the user wouldn't usually see if data is loading or if content is pushed if the table changes height, so this shouldn't be an issue.

I any case, it's easy to revert if something bad happens.

It should look like this when empty:

![Screen Shot 2020-11-26 at 15 00 46](https://user-images.githubusercontent.com/4015436/100384852-e203d500-2fff-11eb-809c-b20d3c7fdb16.png)

No changes for tables with content:

![Screen Shot 2020-11-26 at 15 56 52](https://user-images.githubusercontent.com/4015436/100384930-11b2dd00-3000-11eb-9a5a-de9035fb09f3.png)
