### PR TITLE
'Use Position Balance ($0.00)' should be disabled when no positions to merge are selected

### DIFF
--- a/src/pages/MergePositions/Contents.tsx
+++ b/src/pages/MergePositions/Contents.tsx
@@ -463,7 +463,7 @@ export const Contents = () => {
           amount={amount}
           balance={maxBalance}
           decimals={decimals}
-          disabled={!condition}
+          disabled={!condition || selectedPositions.length <= 1}
           isFromAPosition={true}
           max={maxBalance.toString()}
           onAmountChange={onAmountChange}


### PR DESCRIPTION
Fix this comment https://github.com/gnosis/conditional-tokens-explorer/issues/653#issuecomment-734230449