### PR TITLE
Avoid interpreting empty string as 0

### DIFF
--- a/src/components/filters/MinMaxFilter/index.tsx
+++ b/src/components/filters/MinMaxFilter/index.tsx
@@ -81,7 +81,8 @@ export const MinMaxFilter: React.FC<Props> = (props) => {
       if (typeof onChangeMin === 'function') {
         onChangeMin(event)
       }
-      setMin(+event.currentTarget.value)
+
+      setMin(event.currentTarget.value.length ? +event.currentTarget.value : null)
     },
     [onChangeMin]
   )
@@ -119,7 +120,8 @@ export const MinMaxFilter: React.FC<Props> = (props) => {
       if (typeof onChangeMax === 'function') {
         onChangeMax(event)
       }
-      setMax(+event.currentTarget.value)
+
+      setMax(event.currentTarget.value.length ? +event.currentTarget.value : null)
     },
     [onChangeMax]
   )


### PR DESCRIPTION
Closes #630 

The error was that `+''` is 0, then it ran validateBounds that makes the min as 2 without changing the value in the input, if I change the ref there then it is impossible to enter something that starts with '1' because will be replaced by a '2'. Just to clarify, this was working in that way, if you search from 1 to 300 it would search from 2 to 256. The only possible error is given when searching for something with max > min. And for me, it is OK.

Also, if you remove the values and get the arrow disabled the search is not repeated, the bug is fixed but I'm not sure about the rest of the details about the UX of that input. In my opinion, if the user removes the values without using 'clear' is because they want to enter another pair of values, so it is OK for me too. 