### PR TITLE
Fix regression in redeem

### DIFF
--- a/src/pages/PositionsList/index.tsx
+++ b/src/pages/PositionsList/index.tsx
@@ -211,7 +211,7 @@ export const PositionsList = () => {
       const { collateralTokenERC1155, conditions, id, userBalanceERC20, userBalanceERC1155 } = row
       const userHasERC1155Balance = userBalanceERC1155 && !userBalanceERC1155.isZero()
       const userHasERC20Balance = userBalanceERC20 && !userBalanceERC20.isZero()
-      const isRedeemable = conditions.every((c) => c.resolved)
+      const isRedeemable = conditions.some((c) => c.resolved)
 
       const menu = [
         {

--- a/src/pages/RedeemPosition/Contents.tsx
+++ b/src/pages/RedeemPosition/Contents.tsx
@@ -184,7 +184,7 @@ export const Contents = () => {
   const onFilterCallback = (positions: PositionWithUserBalanceWithDecimals[]) => {
     return positions.filter(
       (position: PositionWithUserBalanceWithDecimals) =>
-        position.conditions.every((condition) => condition.resolved) &&
+        position.conditions.some((condition) => condition.resolved) &&
         !position.userBalanceERC1155.isZero()
     )
   }

--- a/src/pages/RedeemPosition/Contents.tsx
+++ b/src/pages/RedeemPosition/Contents.tsx
@@ -1,5 +1,3 @@
-import { ethers } from 'ethers'
-import { BigNumber } from 'ethers/utils'
 import React, { useCallback, useMemo, useState } from 'react'
 import { Prompt } from 'react-router'
 
@@ -17,10 +15,10 @@ import { USE_CPK } from 'config/constants'
 import { Web3ContextStatus, useWeb3ConnectedOrInfura } from 'contexts/Web3Context'
 import { useCondition } from 'hooks/useCondition'
 import { PositionWithUserBalanceWithDecimals } from 'hooks/usePositionsList'
-import { ConditionalTokensService } from 'services/conditionalTokens'
 import { CPKService } from 'services/cpk'
 import { getLogger } from 'util/logger'
 import { Remote } from 'util/remoteData'
+import { getParentCollectionId } from 'util/tools'
 
 const logger = getLogger('RedeemPosition')
 
@@ -61,17 +59,8 @@ export const Contents = () => {
         setTransactionStatus(Remote.loading())
 
         const { collateralToken, conditionIds, indexSets } = position
-        const newCollectionsSet = conditionIds.reduce(
-          (acc, condId, i) =>
-            condId !== conditionId
-              ? [...acc, { conditionId, indexSet: new BigNumber(indexSets[i]) }]
-              : acc,
-          new Array<{ conditionId: string; indexSet: BigNumber }>()
-        )
-        const parentCollectionId = newCollectionsSet.length
-          ? ConditionalTokensService.getCombinedCollectionId(newCollectionsSet)
-          : ethers.constants.HashZero
 
+        const parentCollectionId = getParentCollectionId(indexSets, conditionIds, conditionId)
         // This UI only allows to redeem 1 position although it's possible to redeem multiple position when you the user owns different positions with the same set of conditions and several indexSets for the resolved condition.
         // i.e.
         // - DAI C:0x123 0:0b01 && C:0x345 O:0b01

--- a/src/pages/RedeemPosition/Contents.tsx
+++ b/src/pages/RedeemPosition/Contents.tsx
@@ -174,10 +174,13 @@ export const Contents = () => {
   )
 
   const onRowClicked = useCallback((position: PositionWithUserBalanceWithDecimals) => {
+    const resolvedConditionsIds = position.conditions
+      .filter((c) => c.resolved)
+      .map((c) => c.conditionId)
     setIsLoadingConditionIds(true)
     setPosition(position)
-    setConditionIds(position.conditionIds)
-    setConditionId(position.conditionIds[0])
+    setConditionIds(resolvedConditionsIds)
+    setConditionId(resolvedConditionsIds[0])
     setIsLoadingConditionIds(false)
   }, [])
 

--- a/src/util/tools.test.ts
+++ b/src/util/tools.test.ts
@@ -756,7 +756,7 @@ test('getParentCollection depth > 1 and second condition', async () => {
   ).toBe('0x6a3582e97ac103071a470d04cb3036c307f0f8a8b91e5a2c5d4c5a4371e24f10')
 })
 
-test('getParentCollection depth = 2 and first of two conditions resolved', async () => {
+test('getParentCollection depth = 2 A', async () => {
   expect(
     getParentCollectionId(
       ['8', '1'],
@@ -769,7 +769,7 @@ test('getParentCollection depth = 2 and first of two conditions resolved', async
   ).toBe('0x2fb72d59493bdec15bafb1dbb6a93407bbfd2d3f1346939c5725215bb3b774ab')
 })
 
-test('getParentCollection depth = 2 and second of two conditions resolved', async () => {
+test('getParentCollection depth = 2 B', async () => {
   expect(
     getParentCollectionId(
       ['8', '1'],
@@ -790,4 +790,17 @@ test('getParentCollection depth = 1 and first condition resolved', async () => {
       '0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb'
     )
   ).toBe('0x0000000000000000000000000000000000000000000000000000000000000000')
+})
+
+test('getParentCollection depth = 2 C', async () => {
+  expect(
+    getParentCollectionId(
+      ['1', '8'],
+      [
+        '0x6abc84f342efc291c72dbfd278ab3e4c045bb3de9ca9310f1503a3dca8a42ccd',
+        '0x20833caaecc79024050dc351445db3008593a9cd5596378496f5daac5fad3ae7',
+      ],
+      '0x6abc84f342efc291c72dbfd278ab3e4c045bb3de9ca9310f1503a3dca8a42ccd'
+    )
+  ).toBe('0x55d6b2977dea10366b353817d510cc4be6451bdf49f3d9a1ab50413e71ba9663')
 })

--- a/src/util/tools.test.ts
+++ b/src/util/tools.test.ts
@@ -753,7 +753,7 @@ test('getParentCollection depth > 1 and second condition', async () => {
       ],
       '0xfb8de9ceffa8431c00c2bf1a22b343a2bcbeba65f08ed41fc25c231ad44ff724'
     )
-  ).toBe('0x4adb0fa03dea49bf1b4a70c49ce524c48fb445810bb993fab2581c9596649749')
+  ).toBe('0x6a3582e97ac103071a470d04cb3036c307f0f8a8b91e5a2c5d4c5a4371e24f10')
 })
 
 test('getParentCollection depth = 2 and first of two conditions resolved', async () => {
@@ -766,7 +766,7 @@ test('getParentCollection depth = 2 and first of two conditions resolved', async
       ],
       '0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb'
     )
-  ).toBe('0x1a138aec008614dabc4d7c7068558fce7566059c54cfed43e9f9c24b0f708e66')
+  ).toBe('0x2fb72d59493bdec15bafb1dbb6a93407bbfd2d3f1346939c5725215bb3b774ab')
 })
 
 test('getParentCollection depth = 2 and second of two conditions resolved', async () => {
@@ -779,7 +779,7 @@ test('getParentCollection depth = 2 and second of two conditions resolved', asyn
       ],
       '0x80adf18b977d760304618d1911fb4b01f4b762e567b08783b98dbdacd891149f'
     )
-  ).toBe('0x10677f94b7bad290b26fb5af9556859c30558c22d66926f909088a2e48d88cad')
+  ).toBe('0x1070e20a2197dc5a6ae892d6b14c21dd87c683fdb9787d5126df9a618ad09646')
 })
 
 test('getParentCollection depth = 1 and first condition resolved', async () => {

--- a/src/util/tools.test.ts
+++ b/src/util/tools.test.ts
@@ -6,6 +6,7 @@ import {
   arePositionMergeables,
   arePositionMergeablesByCondition,
   getMergePreview,
+  getParentCollectionId,
   getRedeemedBalance,
   getRedeemedPreview,
   indexSetFromOutcomes,
@@ -727,4 +728,66 @@ test('indexSetFromOutcomes should return ORed values', async () => {
   expect(
     indexSetFromOutcomes(['1606938044258990275541962092341162602522202993782792835301376', '4'])
   ).toBe('1606938044258990275541962092341162602522202993782792835301380')
+})
+
+test('getParentCollection depth > 1 and first condition', async () => {
+  expect(
+    getParentCollectionId(
+      ['8', '1'],
+      [
+        '0x3e803fe36846d0b57d002bb00fb4a916ef94787ddd4b7613c4e8090397eda27a',
+        '0xfb8de9ceffa8431c00c2bf1a22b343a2bcbeba65f08ed41fc25c231ad44ff724',
+      ],
+      '0x3e803fe36846d0b57d002bb00fb4a916ef94787ddd4b7613c4e8090397eda27a'
+    )
+  ).toBe('0x296519534592413fb03189b1415f32f130d087ddcf09130e8ca07c5fab5264db')
+})
+
+test('getParentCollection depth > 1 and second condition', async () => {
+  expect(
+    getParentCollectionId(
+      ['1', '1'],
+      [
+        '0x3e803fe36846d0b57d002bb00fb4a916ef94787ddd4b7613c4e8090397eda27a',
+        '0xfb8de9ceffa8431c00c2bf1a22b343a2bcbeba65f08ed41fc25c231ad44ff724',
+      ],
+      '0xfb8de9ceffa8431c00c2bf1a22b343a2bcbeba65f08ed41fc25c231ad44ff724'
+    )
+  ).toBe('0x4adb0fa03dea49bf1b4a70c49ce524c48fb445810bb993fab2581c9596649749')
+})
+
+test('getParentCollection depth = 2 and first of two conditions resolved', async () => {
+  expect(
+    getParentCollectionId(
+      ['8', '1'],
+      [
+        '0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb',
+        '0x80adf18b977d760304618d1911fb4b01f4b762e567b08783b98dbdacd891149f',
+      ],
+      '0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb'
+    )
+  ).toBe('0x1a138aec008614dabc4d7c7068558fce7566059c54cfed43e9f9c24b0f708e66')
+})
+
+test('getParentCollection depth = 2 and second of two conditions resolved', async () => {
+  expect(
+    getParentCollectionId(
+      ['8', '1'],
+      [
+        '0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb',
+        '0x80adf18b977d760304618d1911fb4b01f4b762e567b08783b98dbdacd891149f',
+      ],
+      '0x80adf18b977d760304618d1911fb4b01f4b762e567b08783b98dbdacd891149f'
+    )
+  ).toBe('0x10677f94b7bad290b26fb5af9556859c30558c22d66926f909088a2e48d88cad')
+})
+
+test('getParentCollection depth = 1 and first condition resolved', async () => {
+  expect(
+    getParentCollectionId(
+      ['8'],
+      ['0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb'],
+      '0x2c610099cde2a76bc57b3c0311c4186c7991fa4ecaeaa2a7b4dcf1e74eef46eb'
+    )
+  ).toBe('0x0000000000000000000000000000000000000000000000000000000000000000')
 })

--- a/src/util/tools.ts
+++ b/src/util/tools.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers'
 import { Provider } from 'ethers/providers'
 import { BigNumber, formatUnits, getAddress } from 'ethers/utils'
 import moment from 'moment-timezone'
@@ -9,6 +10,7 @@ import { PositionWithUserBalanceWithDecimals } from 'hooks/usePositionsList'
 import { ConditionInformation } from 'hooks/utils'
 import isEqual from 'lodash.isequal'
 import zipObject from 'lodash.zipobject'
+import { ConditionalTokensService } from 'services/conditionalTokens'
 import { ERC20Service } from 'services/erc20'
 import { GetCondition_condition } from 'types/generatedGQLForCTE'
 import { CollateralErrors, ConditionErrors, NetworkIds, PositionErrors, Token } from 'util/types'
@@ -445,4 +447,21 @@ export const getOmenMarketURL = (marketId: string) => {
 export const isOracleRealitio = (oracleAddress: string, networkConfig: NetworkConfig) => {
   const oracle = networkConfig.getOracleFromAddress(oracleAddress)
   return oracle.name === ('reality' as KnownOracle)
+}
+
+export const getParentCollectionId = (
+  indexSets: string[],
+  conditionIds: string[],
+  conditionId: string
+) => {
+  const newCollectionsSet = conditionIds.reduce(
+    (acc, condId, i) =>
+      condId !== conditionId
+        ? [...acc, { conditionId, indexSet: new BigNumber(indexSets[i]) }]
+        : acc,
+    new Array<{ conditionId: string; indexSet: BigNumber }>()
+  )
+  return newCollectionsSet.length
+    ? ConditionalTokensService.getCombinedCollectionId(newCollectionsSet)
+    : ethers.constants.HashZero
 }

--- a/src/util/tools.ts
+++ b/src/util/tools.ts
@@ -455,9 +455,9 @@ export const getParentCollectionId = (
   conditionId: string
 ) => {
   const newCollectionsSet = conditionIds.reduce(
-    (acc, condId, i) =>
-      condId !== conditionId
-        ? [...acc, { conditionId, indexSet: new BigNumber(indexSets[i]) }]
+    (acc, id, i) =>
+      id !== conditionId
+        ? [...acc, { conditionId: id, indexSet: new BigNumber(indexSets[i]) }]
         : acc,
     new Array<{ conditionId: string; indexSet: BigNumber }>()
   )


### PR DESCRIPTION
Closes #641 
Closes #643 

The `reduce` to calculate `parentCollectionId`  was wrong after some refactor or some kind of typo, I'm not sure. This was difficult to find during development because it only happens for positions of depth > 1, also the redeem was only showing positions with all the conditions resolved. I've fixed that and created a few tests after extracting that functionality outside the component.

@elena-zh I think the test cases here are
- positions with all conditions resolved should give collateral (1)
- positions with some conditions resolved should give outcome tokens
- positions without conditions resolved shouldn't be available for redeeming.

For simplicity, C1, C2 and C3 will have only 2 outcomes.

(1)
```
10DAI + C1 => 10 C1P1 + 10C1P2
10 C1P1 + C2 => 10C1C2P1 + 10C1C2P2
10 C1C2P1 + C3 => 10C1C2C3P1 + 10C1C2C3P1

If payouts for C3 are [1,0], and for C2 [0.5, 0.5] and for C1 [0.1,0.9], you will receive

(10C1C2C3P1 * 1) = 10C1C2P1
(10C1C2P1 * 0.5) =  5 C1P1
(5 C1P1 * 0.1) = 0.5 DAI
```