### PR TITLE
(Fix) UI issues with 'Omen Market(s)'

### DIFF
--- a/src/components/form/DisplayTableHashes/index.tsx
+++ b/src/components/form/DisplayTableHashes/index.tsx
@@ -1,13 +1,21 @@
 import React, { useCallback } from 'react'
 import DataTable from 'react-data-table-component'
+import styled from 'styled-components'
 
 import { ButtonCopy } from 'components/buttons/ButtonCopy'
 import { ExternalLink } from 'components/navigation/ExternalLink'
 import { EmptyContentText } from 'components/pureStyledComponents/EmptyContentText'
-import { FlexRow } from 'components/pureStyledComponents/FlexRow'
 import { Hash } from 'components/text/Hash'
 import { customStyles } from 'theme/tableCustomStyles'
 import { HashArray } from 'util/types'
+
+const Text = styled.span`
+  display: block;
+  max-width: 90%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
 
 interface Props {
   callbackOnHistoryPush?: () => void
@@ -24,26 +32,22 @@ export const DisplayTableHashes = (props: Props) => {
       {
         // eslint-disable-next-line react/display-name
         cell: ({ hash, title, url }: HashArray) => {
-          if (title) {
-            return (
-              <FlexRow>
-                {title}
-                <ButtonCopy value={hash} />
-                {url && <ExternalLink href={url} />}
-              </FlexRow>
-            )
-          } else {
-            return (
-              <Hash
-                externalLink
-                {...(url && { href: `${url}` })}
-                onClick={() => {
-                  if (typeof callbackOnHistoryPush === 'function') callbackOnHistoryPush()
-                }}
-                value={hash}
-              />
-            )
-          }
+          return title ? (
+            <>
+              <Text title={title}>{title}</Text>
+              <ButtonCopy value={hash} />
+              {url && <ExternalLink href={url} />}
+            </>
+          ) : (
+            <Hash
+              externalLink
+              {...(url && { href: `${url}` })}
+              onClick={() => {
+                if (typeof callbackOnHistoryPush === 'function') callbackOnHistoryPush()
+              }}
+              value={hash}
+            />
+          )
         },
         name: titleTable,
       },

--- a/src/components/modals/DisplayHashesTableModal/index.tsx
+++ b/src/components/modals/DisplayHashesTableModal/index.tsx
@@ -9,6 +9,11 @@ const Table = styled(DisplayTableHashes)`
   &.noMarginBottom {
     margin-bottom: 0;
   }
+
+  &.constrainContents .rdt_Table {
+    max-width: 100%;
+    min-width: 0;
+  }
 `
 
 interface Props extends ModalProps {
@@ -27,7 +32,7 @@ export const DisplayHashesTableModal = (props: Props) => {
       title={title}
       {...restProps}
     >
-      <Table className="noMarginBottom" hashes={hashes} titleTable={titleTable} />
+      <Table className="noMarginBottom constrainContents" hashes={hashes} titleTable={titleTable} />
     </Modal>
   )
 }


### PR DESCRIPTION
Closes #627

> Still, 'Navigate' icon is displayed in a separate line when an omen market text fits (...)

That's OK, it follows the natural flow of text. Doing anything else would be time consuming for something the user won't see too often.

> Questions (markets) are not wrapped, copy and navigate icons are displayed (...)

For this case I simply cut the text gracefully. It should fit now.

> Questions (markets) are placed in the order 'Last created at the top' in the Omen Markets pop-up (...)

I don't know if this is a problem (isn't that the default order?), but if it is I don't know how to fix it. I wouldn't change it, not a big deal.

> Sometimes Omen Market(s) section is blinking after being loaded (...)

I think Elena and I talked about this in another PR, and she probably created an issue for this problem. It she didn't, I think it deserves a separate issue.