### PR TITLE
Pass filter to usePositionsList to only show positions with balance

### DIFF
--- a/src/components/filters/WithBalanceFilterDropdown/index.tsx
+++ b/src/components/filters/WithBalanceFilterDropdown/index.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import { ButtonSelectLight } from 'components/buttons/ButtonSelectLight'
+import { DropdownItem, DropdownPosition } from 'components/common/Dropdown'
+import { FilterDropdown } from 'components/pureStyledComponents/FilterDropdown'
+import {
+  FilterTitle,
+  FilterTitleButton,
+  FilterWrapper,
+} from 'components/pureStyledComponents/FilterTitle'
+import { WithBalanceOptions } from 'util/types'
+
+const Wrapper = styled.div``
+
+interface Props {
+  onClear?: () => void
+  onClick: (value: WithBalanceOptions) => void
+  value: string
+}
+
+export const WithBalanceFilterDropdown: React.FC<Props> = (props) => {
+  const { onClear, onClick, value, ...restProps } = props
+
+  const dropdownItems = [
+    {
+      onClick: () => {
+        onClick(WithBalanceOptions.All)
+      },
+      text: 'All',
+      value: WithBalanceOptions.All,
+    },
+    {
+      onClick: () => {
+        onClick(WithBalanceOptions.Yes)
+      },
+      text: 'Yes',
+      value: WithBalanceOptions.Yes,
+    },
+    {
+      onClick: () => {
+        onClick(WithBalanceOptions.No)
+      },
+      text: 'No',
+      value: WithBalanceOptions.No,
+    },
+  ]
+
+  return (
+    <Wrapper {...restProps}>
+      <FilterWrapper>
+        <FilterTitle>With Balance</FilterTitle>
+        {onClear && <FilterTitleButton onClick={onClear}>Clear</FilterTitleButton>}
+      </FilterWrapper>
+      <FilterDropdown
+        currentItem={dropdownItems.findIndex((item) => item.value === value)}
+        dropdownButtonContent={
+          <ButtonSelectLight
+            content={dropdownItems.filter((item) => item.value === value)[0].text}
+          />
+        }
+        dropdownPosition={DropdownPosition.center}
+        items={dropdownItems.map((item, index) => (
+          <DropdownItem key={index} onClick={item.onClick}>
+            {item.text}
+          </DropdownItem>
+        ))}
+      />
+    </Wrapper>
+  )
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -34,6 +34,12 @@ export enum WrappedCollateralOptions {
   No = 'no',
 }
 
+export enum WithBalanceOptions {
+  All = 'all',
+  Yes = 'yes',
+  No = 'no',
+}
+
 export enum ValidityOptions {
   All = 'all',
   Invalid = 'invalid',


### PR DESCRIPTION
Closes #750
That is what Auryn asked in the last sync. Is just a client-side filter function passed to the actual hook for positions. 

Maybe we can use that kind of filtering for everything but is not a big improvement if we continue using 'no-cache', because we will need to fetch everything in sections where the query narrows the result. Doing this full fetch only once seems fine but in each positions fetch can be a problem right now.