### PR TITLE
Remove positions from fragment

### DIFF
--- a/src/queries/CTEConditions.tsx
+++ b/src/queries/CTEConditions.tsx
@@ -55,12 +55,6 @@ const conditionFragment = gql`
     payoutDenominator
     resolveTimestamp
     resolveBlockNumber
-    positions {
-      id
-      collateralToken {
-        id
-      }
-    }
   }
 `
 export const buildQueryConditionsList = (

--- a/src/types/generatedGQLForCTE.ts
+++ b/src/types/generatedGQLForCTE.ts
@@ -30,17 +30,6 @@ export interface PaginatedConditionsVariables {
 // GraphQL query operation: ConditionsList
 // ====================================================
 
-export interface ConditionsList_conditions_positions_collateralToken {
-  __typename: "CollateralToken";
-  id: string;
-}
-
-export interface ConditionsList_conditions_positions {
-  __typename: "Position";
-  id: string;
-  collateralToken: ConditionsList_conditions_positions_collateralToken;
-}
-
 export interface ConditionsList_conditions {
   __typename: "Condition";
   id: string;
@@ -55,7 +44,6 @@ export interface ConditionsList_conditions {
   payoutDenominator: any | null;
   resolveTimestamp: any | null;
   resolveBlockNumber: any | null;
-  positions: ConditionsList_conditions_positions[] | null;
 }
 
 export interface ConditionsList {
@@ -71,17 +59,6 @@ export interface ConditionsList {
 // GraphQL query operation: GetCondition
 // ====================================================
 
-export interface GetCondition_condition_positions_collateralToken {
-  __typename: "CollateralToken";
-  id: string;
-}
-
-export interface GetCondition_condition_positions {
-  __typename: "Position";
-  id: string;
-  collateralToken: GetCondition_condition_positions_collateralToken;
-}
-
 export interface GetCondition_condition {
   __typename: "Condition";
   id: string;
@@ -96,7 +73,6 @@ export interface GetCondition_condition {
   payoutDenominator: any | null;
   resolveTimestamp: any | null;
   resolveBlockNumber: any | null;
-  positions: GetCondition_condition_positions[] | null;
 }
 
 export interface GetCondition {
@@ -504,17 +480,6 @@ export interface UserPositionBalancesVariables {
 // GraphQL fragment: ConditionData
 // ====================================================
 
-export interface ConditionData_positions_collateralToken {
-  __typename: "CollateralToken";
-  id: string;
-}
-
-export interface ConditionData_positions {
-  __typename: "Position";
-  id: string;
-  collateralToken: ConditionData_positions_collateralToken;
-}
-
 export interface ConditionData {
   __typename: "Condition";
   id: string;
@@ -529,7 +494,6 @@ export interface ConditionData {
   payoutDenominator: any | null;
   resolveTimestamp: any | null;
   resolveBlockNumber: any | null;
-  positions: ConditionData_positions[] | null;
 }
 
 /* tslint:disable */


### PR DESCRIPTION
Closes #752 

This type checks correctly and works as far as I tested. Querying positions for conditions seems like something that was left by an old feature or another approach to solve something else and doesn't seems to be used anymore. This and the improvements in the index from @davidalbela should make that conditions list works again (and hopefully faster than before).