### PR TITLE
Add clear date to prepare condition

### DIFF
--- a/src/pages/PrepareCondition/index.tsx
+++ b/src/pages/PrepareCondition/index.tsx
@@ -16,6 +16,7 @@ import { CategoriesDropdown } from 'components/form/CategoriesDropdown'
 import { ConditionTypesDropdown } from 'components/form/ConditionTypesDropdown'
 import { ButtonContainer } from 'components/pureStyledComponents/ButtonContainer'
 import { ErrorContainer, Error as ErrorMessage } from 'components/pureStyledComponents/Error'
+import { FilterTitleButton, FilterWrapper } from 'components/pureStyledComponents/FilterTitle'
 import { Row } from 'components/pureStyledComponents/Row'
 import { SmallNote } from 'components/pureStyledComponents/SmallNote'
 import { Textfield } from 'components/pureStyledComponents/Textfield'
@@ -130,6 +131,7 @@ export const PrepareCondition = () => {
   } = formStateCustomCondition
 
   const {
+    clearError: clearErrorOmenCondition,
     control: omenControl,
     errors: errorsOmenCondition,
     formState: formStateOmenCondition,
@@ -729,6 +731,18 @@ export const PrepareCondition = () => {
                 title="Resolution Date"
                 value={
                   <>
+                    <FilterWrapper>
+                      <FilterTitleButton
+                        disabled={!getValuesOmenCondition().resolutionDate}
+                        onClick={() => {
+                          setValueOmenCondition('resolutionDate', null)
+                          clearErrorOmenCondition('resolutionDate')
+                        }}
+                      >
+                        Clear
+                      </FilterTitleButton>
+                    </FilterWrapper>
+
                     <Textfield
                       error={errorsOmenCondition.resolutionDate && true}
                       max={MAX_DATE}

--- a/src/pages/PrepareCondition/index.tsx
+++ b/src/pages/PrepareCondition/index.tsx
@@ -16,11 +16,10 @@ import { CategoriesDropdown } from 'components/form/CategoriesDropdown'
 import { ConditionTypesDropdown } from 'components/form/ConditionTypesDropdown'
 import { ButtonContainer } from 'components/pureStyledComponents/ButtonContainer'
 import { ErrorContainer, Error as ErrorMessage } from 'components/pureStyledComponents/Error'
-import { FilterTitleButton, FilterWrapper } from 'components/pureStyledComponents/FilterTitle'
 import { Row } from 'components/pureStyledComponents/Row'
 import { SmallNote } from 'components/pureStyledComponents/SmallNote'
 import { Textfield } from 'components/pureStyledComponents/Textfield'
-import { TitleControl } from 'components/pureStyledComponents/TitleControl'
+import { TitleControl, TitleControlButton } from 'components/pureStyledComponents/TitleControl'
 import { FullLoading } from 'components/statusInfo/FullLoading'
 import { StatusInfoInline, StatusInfoType } from 'components/statusInfo/StatusInfoInline'
 import { IconTypes } from 'components/statusInfo/common'
@@ -192,6 +191,12 @@ export const PrepareCondition = () => {
   const onChangeOutcome = (e: ChangeEvent<HTMLInputElement>) => {
     setOutcome(e.currentTarget.value)
   }
+
+  const clearResolutionDateEnabled = useMemo(() => {
+    const resolutionDateHasError = !!errorsOmenCondition.resolutionDate
+    const resolutionDateNotEmpty = resolutionDate !== null && resolutionDate !== ''
+    return resolutionDateNotEmpty || resolutionDateHasError
+  }, [errorsOmenCondition.resolutionDate, resolutionDate])
 
   useEffect(() => {
     const getConditionIdPreview = async () => {
@@ -729,20 +734,19 @@ export const PrepareCondition = () => {
             <Row>
               <TitleValue
                 title="Resolution Date"
+                titleControl={
+                  <TitleControlButton
+                    disabled={!clearResolutionDateEnabled}
+                    onClick={() => {
+                      setValueOmenCondition('resolutionDate', null)
+                      clearErrorOmenCondition('resolutionDate')
+                    }}
+                  >
+                    Clear
+                  </TitleControlButton>
+                }
                 value={
                   <>
-                    <FilterWrapper>
-                      <FilterTitleButton
-                        disabled={!getValuesOmenCondition().resolutionDate}
-                        onClick={() => {
-                          setValueOmenCondition('resolutionDate', null)
-                          clearErrorOmenCondition('resolutionDate')
-                        }}
-                      >
-                        Clear
-                      </FilterTitleButton>
-                    </FilterWrapper>
-
                     <Textfield
                       error={errorsOmenCondition.resolutionDate && true}
                       max={MAX_DATE}


### PR DESCRIPTION
Closes #617 

I'm not sure where to put the "clear" text. I've used a component used for filters but maybe it should be right-aligned. The errors of `resolutionDate` are cleared too. 

 
![Captura de pantalla de 2020-12-18 18-15-07](https://user-images.githubusercontent.com/358059/102662192-13824300-415d-11eb-8cd1-c6ae462e3909.png)
