### PR TITLE
(fix) Cut dropdown

### DIFF
--- a/src/components/common/Dropdown/index.tsx
+++ b/src/components/common/Dropdown/index.tsx
@@ -187,17 +187,18 @@ export const Dropdown: React.FC<Props> = (props) => {
   )
 
   useEffect(() => {
+    // Note: you can use triggerClose to close the dropdown when clicking on a specific element
     if (triggerClose) {
       setIsOpen(false)
     }
-  }, [triggerClose])
 
-  useEffect(() => {
+    // Note: This code handles closing when clickin outside of the dropdown
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const handleClick = (e: any) => {
       if (node && node.current && node.current.contains(e.target)) {
         return
       }
+      setIsOpen(false)
     }
 
     document.addEventListener('mousedown', handleClick)
@@ -205,7 +206,7 @@ export const Dropdown: React.FC<Props> = (props) => {
     return () => {
       document.removeEventListener('mousedown', handleClick)
     }
-  }, [node])
+  }, [node, triggerClose])
 
   return (
     <Wrapper

--- a/src/components/common/PageOptions/index.tsx
+++ b/src/components/common/PageOptions/index.tsx
@@ -121,8 +121,8 @@ interface DropdownContentProps {
   onApply: (items: any[]) => void
   onTriggerClose: (value: boolean) => void
   options: Array<{
-    mandatory?: boolean
     isVisible?: boolean
+    mandatory?: boolean
     name: string
   }>
 }

--- a/src/hooks/useLocalStorageValue.tsx
+++ b/src/hooks/useLocalStorageValue.tsx
@@ -1,9 +1,5 @@
 import { useCallback } from 'react'
 
-import { getLogger } from 'util/logger'
-
-const logger = getLogger('useLocalStorage')
-
 export const useLocalStorage = <T extends string>(key: T) => {
   const getValue = useCallback(
     (removeValue = true) => {
@@ -11,7 +7,6 @@ export const useLocalStorage = <T extends string>(key: T) => {
       if (removeValue) window.localStorage.removeItem(key)
 
       if (t) {
-        logger.log(t)
         return JSON.parse(t)
       } else {
         return ''


### PR DESCRIPTION
Closes #658 

Table container should fill all available height now, so dropdowns should be always fully visible (even if there are only a few rows).

Only possible exception is when screen height is extremely low.

**Note:** all of the table's dropdowns are going away on the next design iteration, so let's not spend a lot of time dealing with this.

**Screenshot:**

![Screen Shot 2020-12-22 at 16 58 22](https://user-images.githubusercontent.com/4015436/102928691-f0ff6b00-4477-11eb-8300-aa80c6ee80e4.png)
