### PR TITLE
Save columns shown in position list by networkName and status

### DIFF
--- a/src/pages/PositionsList/index.tsx
+++ b/src/pages/PositionsList/index.tsx
@@ -127,7 +127,11 @@ export const PositionsList = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [columns, setColumns] = useState<any[]>([])
 
-  const { getValue, setValue } = useLocalStorage('positionListColumns')
+  const { getValue, setValue } = useLocalStorage(
+    `positionListColumns-${networkConfig.getNetworkName()}-${
+      status === Web3ContextStatus.Connected ? 'online' : 'offline'
+    }`
+  )
 
   const debouncedHandlerTextToSearch = useDebounceCallback((textToSearch) => {
     setTextToSearch(textToSearch)
@@ -304,7 +308,7 @@ export const PositionsList = () => {
   )
 
   useEffect(() => {
-    const columnsSaved = getValue()
+    const columnsSaved = getValue(false)
 
     const columnsDefault = [
       {


### PR DESCRIPTION
Closes #768 
Closes #769 

Those "bugs" seem like a feature, without using localStorage we can get the reset of filters on network change, but maybe the idea was to maintain the config by network-status, so I change the key according to that.  