### PR TITLE
Complex split: an additional token's amount is taken from the wallet when split position

### DIFF
--- a/src/services/cpk.ts
+++ b/src/services/cpk.ts
@@ -5,7 +5,7 @@ import { Moment } from 'moment'
 import { toChecksumAddress } from 'web3-utils'
 
 import { txs } from '@gnosis.pm/safe-apps-sdk/dist/txs'
-import { CONFIRMATIONS_TO_WAIT } from 'config/constants'
+import { CONFIRMATIONS_TO_WAIT, NULL_PARENT_ID } from 'config/constants'
 import { NetworkConfig } from 'config/networkConfig'
 import CPK from 'contract-proxy-kit/lib/esm'
 import EthersAdapter from 'contract-proxy-kit/lib/esm/ethLibAdapters/EthersAdapter'
@@ -367,7 +367,7 @@ class CPKService {
     }
 
     // If we are signed in as a safe we don't need to transfer
-    if (!this.cpk.isSafeApp()) {
+    if (!this.cpk.isSafeApp() && parentCollectionId.toLowerCase() === NULL_PARENT_ID.toLowerCase()) {
       // Transfer amount from user
       transactions.push({
         to: collateralToken,

--- a/src/services/cpk.ts
+++ b/src/services/cpk.ts
@@ -367,7 +367,10 @@ class CPKService {
     }
 
     // If we are signed in as a safe we don't need to transfer
-    if (!this.cpk.isSafeApp() && parentCollectionId.toLowerCase() === NULL_PARENT_ID.toLowerCase()) {
+    if (
+      !this.cpk.isSafeApp() &&
+      parentCollectionId.toLowerCase() === NULL_PARENT_ID.toLowerCase()
+    ) {
       // Transfer amount from user
       transactions.push({
         to: collateralToken,


### PR DESCRIPTION
Closes #773 


1 step. create a condition
2. split positions for it (C1P1+C1P2)
3. create condition C2
4. split: condition C2+ select position option (and use C1P1). Do not split the whole amount. split 1 token, as an example (edited) 
and you will see than an additional token (1) is taken from the wallet balance. but it should not behave this way
no additional tokens can be taken when split a position  using the 'Position' option