### PR TITLE
Add spinner  while outcomes load

### DIFF
--- a/src/components/partitions/Outcome/index.tsx
+++ b/src/components/partitions/Outcome/index.tsx
@@ -101,8 +101,8 @@ const BaseOutcome: React.FC<Props> = (props) => {
   } = props
 
   const tooltipInfo = outcome.id
-  const outcomeText = outcome.text ? `<div><strong>value:</strong> ${outcome.text}</div>` : ''
-  const tooltipText = `<div><div><strong>id:</strong> ${outcome.id}</div>${outcomeText}</div>`
+  const outcomeText = outcome.text ? `<div><strong>Value:</strong> ${outcome.text}</div>` : ''
+  const tooltipText = `<div><div><strong>Id:</strong> ${outcome.id}</div>${outcomeText}</div>`
 
   return (
     <Wrapper

--- a/src/components/partitions/Outcome/index.tsx
+++ b/src/components/partitions/Outcome/index.tsx
@@ -101,8 +101,8 @@ const BaseOutcome: React.FC<Props> = (props) => {
   } = props
 
   const tooltipInfo = outcome.id
-  const outcomeText = outcome.text ? ` - ${outcome.text}` : ''
-  const tooltipText = `id: ${outcome.id}${outcomeText}`
+  const outcomeText = outcome.text ? `<div><strong>value:</strong> ${outcome.text}</div>` : ''
+  const tooltipText = `<div><div><strong>id:</strong> ${outcome.id}</div>${outcomeText}</div>`
 
   return (
     <Wrapper

--- a/src/components/partitions/Outcome/index.tsx
+++ b/src/components/partitions/Outcome/index.tsx
@@ -101,13 +101,15 @@ const BaseOutcome: React.FC<Props> = (props) => {
   } = props
 
   const tooltipInfo = outcome.id
+  const outcomeText = outcome.text ? ` - ${outcome.text}` : ''
+  const tooltipText = `id: ${outcome.id}${outcomeText}`
 
   return (
     <Wrapper
       data-for={`tooltip_${outcome.value}`}
       data-html={true}
       data-multiline={true}
-      data-tip={`id: ${outcome.id}`}
+      data-tip={tooltipText}
       id={id}
       lastInRow={lastInRow}
       onClick={onClick}

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -106,10 +106,11 @@ export const Form = (props: Props) => {
 
   useEffect(() => {
     const numberedOutcomesToSet = originalPartition.map((outcome: BigNumber, key: number) => {
-      return [{ value: key, id: outcome.toString() }]
+      const value = condition && condition.outcomes ? condition.outcomes[key] : key
+      return [{ value, id: outcome.toString() }]
     })
     setNumberedOutcomes(numberedOutcomesToSet)
-  }, [originalPartition, setNumberedOutcomes])
+  }, [condition, originalPartition, setNumberedOutcomes])
 
   const partition = useMemo(() => {
     const outcomes = numberedOutcomes.map((collection) => collection.map((c) => c.id))
@@ -278,6 +279,15 @@ export const Form = (props: Props) => {
     [isSplittingFromCollateral, isValid, allowanceFinished]
   )
 
+  const questionTitle = useMemo(() => {
+    console.log(condition && condition.question)
+    if (condition && condition.question) {
+      return condition.question.title
+    } else {
+      return null
+    }
+  }, [condition])
+
   const outcomesByRow = '14'
 
   const fullLoadingActionButton = useMemo(
@@ -413,30 +423,33 @@ export const Form = (props: Props) => {
               {conditionId && loading ? (
                 <InlineLoading />
               ) : (
-                <StripedListStyled>
-                  {numberedOutcomes && numberedOutcomes.length ? (
-                    numberedOutcomes.map(
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      (outcomeList: OutcomeProps[], outcomeListIndex: number) => {
-                        return (
-                          <StripedListItemLessPadding key={outcomeListIndex}>
-                            <OutcomesContainer columnGap="0" columns={outcomesByRow}>
-                              {outcomeList.map((outcome: OutcomeProps, outcomeIndex: number) => (
-                                <Outcome
-                                  key={outcomeIndex}
-                                  lastInRow={outcomesByRow}
-                                  outcome={outcome}
-                                />
-                              ))}
-                            </OutcomesContainer>
-                          </StripedListItemLessPadding>
-                        )
-                      }
-                    )
-                  ) : (
-                    <StripedListEmpty>No Collections.</StripedListEmpty>
-                  )}
-                </StripedListStyled>
+                <>
+                  {questionTitle && <CardTextSm>{questionTitle}</CardTextSm>}
+                  <StripedListStyled>
+                    {numberedOutcomes && numberedOutcomes.length ? (
+                      numberedOutcomes.map(
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        (outcomeList: OutcomeProps[], outcomeListIndex: number) => {
+                          return (
+                            <StripedListItemLessPadding key={outcomeListIndex}>
+                              <OutcomesContainer columnGap="0" columns={outcomesByRow}>
+                                {outcomeList.map((outcome: OutcomeProps, outcomeIndex: number) => (
+                                  <Outcome
+                                    key={outcomeIndex}
+                                    lastInRow={outcomesByRow}
+                                    outcome={outcome}
+                                  />
+                                ))}
+                              </OutcomesContainer>
+                            </StripedListItemLessPadding>
+                          )
+                        }
+                      )
+                    ) : (
+                      <StripedListEmpty>No Collections.</StripedListEmpty>
+                    )}
+                  </StripedListStyled>
+                </>
               )}
             </>
           }

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -106,8 +106,8 @@ export const Form = (props: Props) => {
 
   useEffect(() => {
     const numberedOutcomesToSet = originalPartition.map((outcome: BigNumber, key: number) => {
-      const value = condition && condition.outcomes ? condition.outcomes[key] : key
-      return [{ value, id: outcome.toString() }]
+      const text = condition && condition.outcomes ? condition.outcomes[key] : undefined
+      return [{ value: key, text, id: outcome.toString() }]
     })
     setNumberedOutcomes(numberedOutcomesToSet)
   }, [condition, originalPartition, setNumberedOutcomes])
@@ -405,6 +405,12 @@ export const Form = (props: Props) => {
           />
         )}
       </Row>
+      {questionTitle && (
+        <Row>
+          <TitleValue title="Question" value={questionTitle} />
+        </Row>
+      )}
+
       <Row paddingTop>
         <TitleValue
           title="Partition"
@@ -422,33 +428,30 @@ export const Form = (props: Props) => {
               {conditionId && loading ? (
                 <InlineLoading />
               ) : (
-                <>
-                  {questionTitle && <CardTextSm>{questionTitle}</CardTextSm>}
-                  <StripedListStyled>
-                    {numberedOutcomes && numberedOutcomes.length ? (
-                      numberedOutcomes.map(
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        (outcomeList: OutcomeProps[], outcomeListIndex: number) => {
-                          return (
-                            <StripedListItemLessPadding key={outcomeListIndex}>
-                              <OutcomesContainer columnGap="0" columns={outcomesByRow}>
-                                {outcomeList.map((outcome: OutcomeProps, outcomeIndex: number) => (
-                                  <Outcome
-                                    key={outcomeIndex}
-                                    lastInRow={outcomesByRow}
-                                    outcome={outcome}
-                                  />
-                                ))}
-                              </OutcomesContainer>
-                            </StripedListItemLessPadding>
-                          )
-                        }
-                      )
-                    ) : (
-                      <StripedListEmpty>No Collections.</StripedListEmpty>
-                    )}
-                  </StripedListStyled>
-                </>
+                <StripedListStyled>
+                  {numberedOutcomes && numberedOutcomes.length ? (
+                    numberedOutcomes.map(
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      (outcomeList: OutcomeProps[], outcomeListIndex: number) => {
+                        return (
+                          <StripedListItemLessPadding key={outcomeListIndex}>
+                            <OutcomesContainer columnGap="0" columns={outcomesByRow}>
+                              {outcomeList.map((outcome: OutcomeProps, outcomeIndex: number) => (
+                                <Outcome
+                                  key={outcomeIndex}
+                                  lastInRow={outcomesByRow}
+                                  outcome={outcome}
+                                />
+                              ))}
+                            </OutcomesContainer>
+                          </StripedListItemLessPadding>
+                        )
+                      }
+                    )
+                  ) : (
+                    <StripedListEmpty>No Collections.</StripedListEmpty>
+                  )}
+                </StripedListStyled>
               )}
             </>
           }

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -24,6 +24,7 @@ import {
 import { TitleControlButton } from 'components/pureStyledComponents/TitleControl'
 import { PositionPreview } from 'components/splitPosition/PositionPreview'
 import { FullLoading } from 'components/statusInfo/FullLoading'
+import { InlineLoading } from 'components/statusInfo/InlineLoading'
 import { StatusInfoInline, StatusInfoType } from 'components/statusInfo/StatusInfoInline'
 import { IconTypes } from 'components/statusInfo/common'
 import { SelectableConditionTable } from 'components/table/SelectableConditionTable'
@@ -95,7 +96,7 @@ export const Form = (props: Props) => {
   const allowanceMethods = useAllowance(collateralAddress)
   const { collateral } = useCollateral(collateralAddress)
 
-  const { condition } = useCondition(conditionId)
+  const { condition, loading } = useCondition(conditionId)
   const outcomeSlot = useMemo(() => (condition ? condition.outcomeSlotCount : 0), [condition])
   const conditionIdToPreviewShow = useMemo(() => (condition ? condition.id : ''), [condition])
 
@@ -400,7 +401,7 @@ export const Form = (props: Props) => {
           title="Partition"
           titleControl={
             <TitleControlButton
-              disabled={!conditionIdToPreviewShow}
+              disabled={!conditionIdToPreviewShow || loading}
               onClick={() => setIsEditPartitionModalOpen(true)}
             >
               Edit Partition
@@ -409,30 +410,34 @@ export const Form = (props: Props) => {
           value={
             <>
               <CardTextSm>Outcomes Collections</CardTextSm>
-              <StripedListStyled>
-                {numberedOutcomes && numberedOutcomes.length ? (
-                  numberedOutcomes.map(
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    (outcomeList: OutcomeProps[], outcomeListIndex: number) => {
-                      return (
-                        <StripedListItemLessPadding key={outcomeListIndex}>
-                          <OutcomesContainer columnGap="0" columns={outcomesByRow}>
-                            {outcomeList.map((outcome: OutcomeProps, outcomeIndex: number) => (
-                              <Outcome
-                                key={outcomeIndex}
-                                lastInRow={outcomesByRow}
-                                outcome={outcome}
-                              />
-                            ))}
-                          </OutcomesContainer>
-                        </StripedListItemLessPadding>
-                      )
-                    }
-                  )
-                ) : (
-                  <StripedListEmpty>No Collections.</StripedListEmpty>
-                )}
-              </StripedListStyled>
+              {conditionId && loading ? (
+                <InlineLoading />
+              ) : (
+                <StripedListStyled>
+                  {numberedOutcomes && numberedOutcomes.length ? (
+                    numberedOutcomes.map(
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      (outcomeList: OutcomeProps[], outcomeListIndex: number) => {
+                        return (
+                          <StripedListItemLessPadding key={outcomeListIndex}>
+                            <OutcomesContainer columnGap="0" columns={outcomesByRow}>
+                              {outcomeList.map((outcome: OutcomeProps, outcomeIndex: number) => (
+                                <Outcome
+                                  key={outcomeIndex}
+                                  lastInRow={outcomesByRow}
+                                  outcome={outcome}
+                                />
+                              ))}
+                            </OutcomesContainer>
+                          </StripedListItemLessPadding>
+                        )
+                      }
+                    )
+                  ) : (
+                    <StripedListEmpty>No Collections.</StripedListEmpty>
+                  )}
+                </StripedListStyled>
+              )}
             </>
           }
         />

--- a/src/pages/SplitPosition/Form.tsx
+++ b/src/pages/SplitPosition/Form.tsx
@@ -280,7 +280,6 @@ export const Form = (props: Props) => {
   )
 
   const questionTitle = useMemo(() => {
-    console.log(condition && condition.question)
     if (condition && condition.question) {
       return condition.question.title
     } else {

--- a/src/queries/CTEConditions.tsx
+++ b/src/queries/CTEConditions.tsx
@@ -55,6 +55,10 @@ const conditionFragment = gql`
     payoutDenominator
     resolveTimestamp
     resolveBlockNumber
+    outcomes
+    question {
+      title
+    }
   }
 `
 export const buildQueryConditionsList = (

--- a/src/types/generatedGQLForCTE.ts
+++ b/src/types/generatedGQLForCTE.ts
@@ -69,6 +69,11 @@ export interface PaginatedConditionsVariables {
 // GraphQL query operation: ConditionsList
 // ====================================================
 
+export interface ConditionsList_conditions_question {
+  __typename: "Question";
+  title: string | null;
+}
+
 export interface ConditionsList_conditions {
   __typename: "Condition";
   id: string;
@@ -83,6 +88,8 @@ export interface ConditionsList_conditions {
   payoutDenominator: any | null;
   resolveTimestamp: any | null;
   resolveBlockNumber: any | null;
+  outcomes: string[] | null;
+  question: ConditionsList_conditions_question | null;
 }
 
 export interface ConditionsList {
@@ -98,6 +105,11 @@ export interface ConditionsList {
 // GraphQL query operation: GetCondition
 // ====================================================
 
+export interface GetCondition_condition_question {
+  __typename: "Question";
+  title: string | null;
+}
+
 export interface GetCondition_condition {
   __typename: "Condition";
   id: string;
@@ -112,6 +124,8 @@ export interface GetCondition_condition {
   payoutDenominator: any | null;
   resolveTimestamp: any | null;
   resolveBlockNumber: any | null;
+  outcomes: string[] | null;
+  question: GetCondition_condition_question | null;
 }
 
 export interface GetCondition {
@@ -590,6 +604,11 @@ export interface UserPositionBalancesVariables {
 // GraphQL fragment: ConditionData
 // ====================================================
 
+export interface ConditionData_question {
+  __typename: "Question";
+  title: string | null;
+}
+
 export interface ConditionData {
   __typename: "Condition";
   id: string;
@@ -604,6 +623,8 @@ export interface ConditionData {
   payoutDenominator: any | null;
   resolveTimestamp: any | null;
   resolveBlockNumber: any | null;
+  outcomes: string[] | null;
+  question: ConditionData_question | null;
 }
 
 /* tslint:disable */

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -142,6 +142,7 @@ export type Arbitrator = {
 export interface OutcomeProps {
   id: string
   value: number
+  text?: string
 }
 
 export enum SplitFromType {


### PR DESCRIPTION
Closes #753 

This has something for #543 

Look like this. For long outcomes names, I think we should use only the id inside the circle and value by the side. 
![Captura de pantalla de 2021-01-18 18-10-21](https://user-images.githubusercontent.com/358059/104963078-83802500-59b8-11eb-82d2-686127eb1fca.png)
![Captura de pantalla de 2021-01-18 18-10-29](https://user-images.githubusercontent.com/358059/104963080-8418bb80-59b8-11eb-89cd-7d583fb8f33a.png)
