### PR TITLE
Unsaved Changes

### DIFF
--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 
 import { ButtonAdd } from 'components/buttons/ButtonAdd'
 import { ButtonControl, ButtonControlType } from 'components/buttons/ButtonControl'
+import { ErrorContainer, Error as ErrorMessage } from 'components/pureStyledComponents/Error'
 import { Row } from 'components/pureStyledComponents/Row'
 import { SmallNote } from 'components/pureStyledComponents/SmallNote'
 import {
@@ -221,11 +222,13 @@ interface Props {
   removeOutcome: (index: number) => void
   updateOutcome: (value: string, index: number) => void
   toggleEditOutcome: (value: boolean, index: number) => void
+  areOutcomesBeingEdited: boolean
 }
 
 export const AddOutcome: React.FC<Props> = (props) => {
   const {
     addOutcome,
+    areOutcomesBeingEdited,
     onChange,
     outcome = '',
     outcomes,
@@ -290,6 +293,11 @@ export const AddOutcome: React.FC<Props> = (props) => {
                 <StripedListEmpty>No outcomes.</StripedListEmpty>
               )}
             </StripedList>
+            {areOutcomesBeingEdited && true && (
+              <ErrorContainer>
+                <ErrorMessage>Unsaved changes</ErrorMessage>
+              </ErrorContainer>
+            )}
             <SmallNote>
               <strong>Note:</strong> Omen supports min. {MIN_OUTCOMES_ALLOWED} and max.{' '}
               {MAX_OUTCOMES_ALLOWED} outcomes.

--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -89,9 +89,11 @@ const EditableOutcome: React.FC<{
   removeOutcome: () => void
   updateOutcome: (value: string, index: number) => void
   onEditOutcome: (value: boolean, index: number) => void
+  onBluredEditingOutcome: (value: boolean) => void
 }> = (props) => {
   const {
     areOutcomesBeingEdited,
+    onBluredEditingOutcome,
     onEditOutcome,
     outcomeIndex,
     outcomeText,
@@ -156,12 +158,19 @@ const EditableOutcome: React.FC<{
     areOutcomesBeingEdited,
   ])
 
+  const onBlurOutcome = useCallback(() => {
+    console.log('lose focus, isEditing: ', isEditing)
+    onBluredEditingOutcome(isEditing)
+  }, [isEditing, onBluredEditingOutcome])
+
   return (
     <OutcomeWrapper title={value} {...restProps}>
       <Outcome
         autoComplete="off"
         error={!isOutcomeValueOK}
+        onBlur={() => onBlurOutcome()}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.value)}
+        onFocus={() => onBluredEditingOutcome(false)}
         onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>) => {
           onPressEnter(e)
         }}
@@ -258,6 +267,8 @@ export const AddOutcome: React.FC<Props> = (props) => {
     }
   }
 
+  const [bluredEditingOutcome, setBluredEditingOutcome] = useState(false)
+
   return (
     <Row {...restProps}>
       <TitleValue
@@ -290,6 +301,7 @@ export const AddOutcome: React.FC<Props> = (props) => {
                   <StripedListItem key={`${index}_${item}`}>
                     <EditableOutcome
                       areOutcomesBeingEdited={areOutcomesBeingEdited}
+                      onBluredEditingOutcome={(value) => setBluredEditingOutcome(value)}
                       onEditOutcome={(value, index) => toggleEditOutcome(value, index)}
                       outcomeIndex={index}
                       outcomeText={item}
@@ -303,7 +315,7 @@ export const AddOutcome: React.FC<Props> = (props) => {
                 <StripedListEmpty>No outcomes.</StripedListEmpty>
               )}
             </StripedList>
-            {areOutcomesBeingEdited && true && (
+            {areOutcomesBeingEdited && bluredEditingOutcome && (
               <ErrorContainer>
                 <ErrorMessage>Unsaved changes</ErrorMessage>
               </ErrorContainer>

--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -86,8 +86,17 @@ const EditableOutcome: React.FC<{
   outcomes: Array<string | undefined>
   removeOutcome: () => void
   updateOutcome: (value: string, index: number) => void
+  onEditOutcome: (value: boolean, index: number) => void
 }> = (props) => {
-  const { outcomeIndex, outcomeText, outcomes, removeOutcome, updateOutcome, ...restProps } = props
+  const {
+    onEditOutcome,
+    outcomeIndex,
+    outcomeText,
+    outcomes,
+    removeOutcome,
+    updateOutcome,
+    ...restProps
+  } = props
   const [isEditing, setIsEditing] = useState(false)
   const [value, setValue] = useState<string | undefined>(outcomeText)
   const outcomeField = createRef<HTMLInputElement>()
@@ -118,8 +127,10 @@ const EditableOutcome: React.FC<{
     if (value) {
       saveSanitizedValue(value)
       setIsEditing(false)
+      onEditOutcome(false, outcomeIndex)
       updateOutcome(value, outcomeIndex)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [updateOutcome, setIsEditing, saveSanitizedValue, value, outcomeIndex])
 
   const onPressEnter = useCallback(
@@ -130,9 +141,11 @@ const EditableOutcome: React.FC<{
       if (e.key === 'Escape') {
         resetValue()
         setIsEditing(false)
+        onEditOutcome(false, outcomeIndex)
       }
     },
-    [setIsEditing, resetValue, isOutcomeValueOK, onSave]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isOutcomeValueOK, onSave, resetValue, outcomeIndex]
   )
 
   return (
@@ -156,6 +169,7 @@ const EditableOutcome: React.FC<{
             buttonType={ButtonControlType.edit}
             onClick={() => {
               setIsEditing(true)
+              onEditOutcome(true, outcomeIndex)
               outcomeField.current?.focus()
             }}
             title="Edit"
@@ -179,6 +193,7 @@ const EditableOutcome: React.FC<{
             onClick={() => {
               resetValue()
               setIsEditing(false)
+              onEditOutcome(false, outcomeIndex)
             }}
             title="Cancel"
           />
@@ -189,6 +204,7 @@ const EditableOutcome: React.FC<{
           onClick={() => {
             removeOutcome()
             setIsEditing(false)
+            onEditOutcome(false, outcomeIndex)
           }}
           title="Remove"
         />
@@ -204,6 +220,7 @@ interface Props {
   outcomes: Array<string>
   removeOutcome: (index: number) => void
   updateOutcome: (value: string, index: number) => void
+  toggleEditOutcome: (value: boolean, index: number) => void
 }
 
 export const AddOutcome: React.FC<Props> = (props) => {
@@ -213,6 +230,7 @@ export const AddOutcome: React.FC<Props> = (props) => {
     outcome = '',
     outcomes,
     removeOutcome,
+    toggleEditOutcome,
     updateOutcome,
     ...restProps
   } = props
@@ -259,6 +277,7 @@ export const AddOutcome: React.FC<Props> = (props) => {
                 outcomes.map((item, index) => (
                   <StripedListItem key={`${index}_${item}`}>
                     <EditableOutcome
+                      onEditOutcome={(value, index) => toggleEditOutcome(value, index)}
                       outcomeIndex={index}
                       outcomeText={item}
                       outcomes={outcomes}

--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -89,11 +89,9 @@ const EditableOutcome: React.FC<{
   removeOutcome: () => void
   updateOutcome: (value: string, index: number) => void
   onEditOutcome: (value: boolean, index: number) => void
-  onBluredEditingOutcome: (value: boolean) => void
 }> = (props) => {
   const {
     areOutcomesBeingEdited,
-    onBluredEditingOutcome,
     onEditOutcome,
     outcomeIndex,
     outcomeText,
@@ -103,6 +101,7 @@ const EditableOutcome: React.FC<{
     ...restProps
   } = props
   const [isEditing, setIsEditing] = useState(false)
+  const [bluredEditingOutcome, setBluredEditingOutcome] = useState(false)
   const [value, setValue] = useState<string | undefined>(outcomeText)
   const outcomeField = createRef<HTMLInputElement>()
 
@@ -159,18 +158,17 @@ const EditableOutcome: React.FC<{
   ])
 
   const onBlurOutcome = useCallback(() => {
-    console.log('lose focus, isEditing: ', isEditing)
-    onBluredEditingOutcome(isEditing)
-  }, [isEditing, onBluredEditingOutcome])
+    setBluredEditingOutcome(isEditing)
+  }, [isEditing, setBluredEditingOutcome])
 
   return (
     <OutcomeWrapper title={value} {...restProps}>
       <Outcome
         autoComplete="off"
-        error={!isOutcomeValueOK}
+        error={!isOutcomeValueOK || bluredEditingOutcome}
         onBlur={() => onBlurOutcome()}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValue(e.currentTarget.value)}
-        onFocus={() => onBluredEditingOutcome(false)}
+        onFocus={() => setBluredEditingOutcome(false)}
         onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>) => {
           onPressEnter(e)
         }}
@@ -267,8 +265,6 @@ export const AddOutcome: React.FC<Props> = (props) => {
     }
   }
 
-  const [bluredEditingOutcome, setBluredEditingOutcome] = useState(false)
-
   return (
     <Row {...restProps}>
       <TitleValue
@@ -301,7 +297,6 @@ export const AddOutcome: React.FC<Props> = (props) => {
                   <StripedListItem key={`${index}_${item}`}>
                     <EditableOutcome
                       areOutcomesBeingEdited={areOutcomesBeingEdited}
-                      onBluredEditingOutcome={(value) => setBluredEditingOutcome(value)}
                       onEditOutcome={(value, index) => toggleEditOutcome(value, index)}
                       outcomeIndex={index}
                       outcomeText={item}
@@ -315,7 +310,7 @@ export const AddOutcome: React.FC<Props> = (props) => {
                 <StripedListEmpty>No outcomes.</StripedListEmpty>
               )}
             </StripedList>
-            {areOutcomesBeingEdited && bluredEditingOutcome && (
+            {areOutcomesBeingEdited && (
               <ErrorContainer>
                 <ErrorMessage>Unsaved changes</ErrorMessage>
               </ErrorContainer>

--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 
 import { ButtonAdd } from 'components/buttons/ButtonAdd'
 import { ButtonControl, ButtonControlType } from 'components/buttons/ButtonControl'
-import { ErrorContainer, Error as ErrorMessage } from 'components/pureStyledComponents/Error'
 import { Row } from 'components/pureStyledComponents/Row'
 import { SmallNote } from 'components/pureStyledComponents/SmallNote'
 import {
@@ -310,11 +309,6 @@ export const AddOutcome: React.FC<Props> = (props) => {
                 <StripedListEmpty>No outcomes.</StripedListEmpty>
               )}
             </StripedList>
-            {areOutcomesBeingEdited && (
-              <ErrorContainer>
-                <ErrorMessage>Unsaved changes</ErrorMessage>
-              </ErrorContainer>
-            )}
             <SmallNote>
               <strong>Note:</strong> Omen supports min. {MIN_OUTCOMES_ALLOWED} and max.{' '}
               {MAX_OUTCOMES_ALLOWED} outcomes.

--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -1,4 +1,4 @@
-import React, { createRef, useCallback, useMemo, useState } from 'react'
+import React, { createRef, useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import { ButtonAdd } from 'components/buttons/ButtonAdd'
@@ -159,6 +159,12 @@ const EditableOutcome: React.FC<{
   const onBlurOutcome = useCallback(() => {
     setBluredEditingOutcome(isEditing)
   }, [isEditing, setBluredEditingOutcome])
+
+  useEffect(() => {
+    if (!isEditing) {
+      setBluredEditingOutcome(false)
+    }
+  }, [isEditing])
 
   return (
     <OutcomeWrapper title={value} {...restProps}>

--- a/src/components/form/AddOutcome/index.tsx
+++ b/src/components/form/AddOutcome/index.tsx
@@ -82,6 +82,7 @@ const isOutcomeTextValid = (outcome: string | undefined): boolean => {
 }
 
 const EditableOutcome: React.FC<{
+  areOutcomesBeingEdited: boolean
   outcomeIndex: number
   outcomeText: string | undefined
   outcomes: Array<string | undefined>
@@ -90,6 +91,7 @@ const EditableOutcome: React.FC<{
   onEditOutcome: (value: boolean, index: number) => void
 }> = (props) => {
   const {
+    areOutcomesBeingEdited,
     onEditOutcome,
     outcomeIndex,
     outcomeText,
@@ -149,6 +151,11 @@ const EditableOutcome: React.FC<{
     [isOutcomeValueOK, onSave, resetValue, outcomeIndex]
   )
 
+  const isEditingOther = useMemo(() => !isEditing && areOutcomesBeingEdited, [
+    isEditing,
+    areOutcomesBeingEdited,
+  ])
+
   return (
     <OutcomeWrapper title={value} {...restProps}>
       <Outcome
@@ -165,7 +172,7 @@ const EditableOutcome: React.FC<{
         value={value}
       />
       <Controls isEditing={isEditing}>
-        {!isEditing && (
+        {!isEditing && !isEditingOther && (
           <ButtonControl
             buttonType={ButtonControlType.edit}
             onClick={() => {
@@ -199,16 +206,18 @@ const EditableOutcome: React.FC<{
             title="Cancel"
           />
         )}
-        <ButtonControl
-          buttonType={ButtonControlType.delete}
-          disabled={isEditing}
-          onClick={() => {
-            removeOutcome()
-            setIsEditing(false)
-            onEditOutcome(false, outcomeIndex)
-          }}
-          title="Remove"
-        />
+        {!isEditingOther && (
+          <ButtonControl
+            buttonType={ButtonControlType.delete}
+            disabled={isEditing}
+            onClick={() => {
+              removeOutcome()
+              setIsEditing(false)
+              onEditOutcome(false, outcomeIndex)
+            }}
+            title="Remove"
+          />
+        )}
       </Controls>
     </OutcomeWrapper>
   )
@@ -280,6 +289,7 @@ export const AddOutcome: React.FC<Props> = (props) => {
                 outcomes.map((item, index) => (
                   <StripedListItem key={`${index}_${item}`}>
                     <EditableOutcome
+                      areOutcomesBeingEdited={areOutcomesBeingEdited}
                       onEditOutcome={(value, index) => toggleEditOutcome(value, index)}
                       outcomeIndex={index}
                       outcomeText={item}

--- a/src/pages/PrepareCondition/index.tsx
+++ b/src/pages/PrepareCondition/index.tsx
@@ -418,6 +418,10 @@ export const PrepareCondition = () => {
     CPKService,
   ])
 
+  const areOutcomesBeingEdited = useMemo(() => outcomesBeingEdited.some(Boolean), [
+    outcomesBeingEdited,
+  ])
+
   const onClickUseMyWallet = useCallback(() => {
     if (status === Web3ContextStatus.Connected && activeAddress) {
       setValueCustomCondition('oracle', activeAddress, true)
@@ -440,16 +444,18 @@ export const PrepareCondition = () => {
           prepareConditionStatus.isFailure() ||
           checkForExistingCondition.isLoading() ||
           checkForExistingCondition.isFailure() ||
+          areOutcomesBeingEdited ||
           isConditionAlreadyExist ||
           isQuestionAlreadyExist ||
           isOutcomesFromOmenConditionInvalid,
     [
-      isValidCustomCondition,
       conditionType,
-      isValidOmenCondition,
+      isValidCustomCondition,
       prepareConditionStatus,
       checkForExistingCondition,
       isConditionAlreadyExist,
+      isValidOmenCondition,
+      areOutcomesBeingEdited,
       isQuestionAlreadyExist,
       isOutcomesFromOmenConditionInvalid,
     ]
@@ -566,10 +572,6 @@ export const PrepareCondition = () => {
 
   const todayLocalized = moment(today).format('LL')
   const maxDateLocalized = moment(MAX_DATE).format('LL')
-
-  const areOutcomesBeingEdited = useMemo(() => outcomesBeingEdited.some(Boolean), [
-    outcomesBeingEdited,
-  ])
 
   return (
     <>
@@ -754,6 +756,7 @@ export const PrepareCondition = () => {
             )}
             <AddOutcome
               addOutcome={addOutcome}
+              areOutcomesBeingEdited={areOutcomesBeingEdited}
               onChange={onChangeOutcome}
               outcome={outcome}
               outcomes={outcomes}
@@ -761,11 +764,6 @@ export const PrepareCondition = () => {
               toggleEditOutcome={toggleEditOutcome}
               updateOutcome={updateOutcome}
             />
-            {areOutcomesBeingEdited && !submitDisabled && (
-              <ErrorContainer>
-                <ErrorMessage>Unsaved changes</ErrorMessage>
-              </ErrorContainer>
-            )}
             <Row>
               <TitleValue
                 title="Resolution Date"


### PR DESCRIPTION
Closes #479 

A message of unsaved changes is shown below the outcomes block only when everything else is completed. I think  we can
- Change the message to live inside `AddOutcome` 
- Always show the message, and use the proper component according to their final position
- Maybe we can just disable the submit, or making something more subtle.

Also, I wasn't sure if the possibility of editing multiple outcomes at the same time is desirable or not.