### PR TITLE
Hotfix Position List skip limit GQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conditional-tokens-explorer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "engines": {
     "node": ">=4.4.7 <=14.15"

--- a/src/contexts/MultiPositionsContext.tsx
+++ b/src/contexts/MultiPositionsContext.tsx
@@ -109,12 +109,14 @@ export const MultiPositionsProvider = (props: Props) => {
     [clearPositions]
   )
 
+  const limit = !positionIds.length < !5000 ? !positionIds.length : !5000
+
   const { data: fetchedPositions, error: errorFetchingPositions, loading: loadingQuery } = useQuery<
     GetMultiPositions
   >(GetMultiPositionsQuery, {
     variables: { ids: positionIds },
     fetchPolicy: 'no-cache',
-    skip: !positionIds.length,
+    skip: limit,
   })
 
   useEffect(() => {

--- a/src/contexts/PositionContext.tsx
+++ b/src/contexts/PositionContext.tsx
@@ -65,6 +65,8 @@ export const PositionProvider = (props: Props) => {
     setPositionId('')
   }, [])
 
+  const limit = !positionId < !5000 ? !positionId : !5000
+
   const {
     data: fetchedPosition,
     error: errorFetchingPosition,
@@ -73,7 +75,7 @@ export const PositionProvider = (props: Props) => {
   } = useQuery<GetPosition>(GetPositionQuery, {
     variables: { id: positionId },
     fetchPolicy: 'no-cache',
-    skip: !positionId,
+    skip: limit,
   })
 
   if (positionId && fetchedPosition) {

--- a/src/hooks/useQueryTotalResults.tsx
+++ b/src/hooks/useQueryTotalResults.tsx
@@ -66,7 +66,7 @@ export function useQueryTotalResults<Result, Variables>(
     setData(null)
     setError(null)
     // eslint-disable-next-line no-constant-condition
-    while (true) {
+    while (skip < 5001) {
       try {
         const { data: lastFetched } = await client.query<Entity<Result>>({
           ...optionsMemo,


### PR DESCRIPTION
Limit to 5000 the `skip` value on the GQL position list. GQL has a limit of 5000 element for the skip parameter.