### PR TITLE
Bump version `v0.3.2`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,12 @@
+Version 0.3.2 (2021-11-02)
+==========================
+
+- Bump url-parse from 1.5.1 to 1.5.3 #861
+- Enable Wrap button for Position Details #1914d5a
+- Disable Wrap and Unwrapp features from Position list #e7cde29
+- Fix React Hook useCallback has missing dependencies from Unwrap modal #b2db9fc
+- Fix formatBigNumber format check #e364b6d
+
 Version 0.3.1 (2021-09-08)
 ==========================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conditional-tokens-explorer",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "engines": {
     "node": ">=4.4.7 <=14.20"


### PR DESCRIPTION
- Bump url-parse from 1.5.1 to 1.5.3 #861
- Enable Wrap button for Position Details #1914d5a
- Disable Wrap and Unwrapp features from Position list #e7cde29
- Fix React Hook useCallback has missing dependencies from Unwrap modal #b2db9fc
- Fix formatBigNumber format check #e364b6d